### PR TITLE
Delay asking of permissions until the component is used

### DIFF
--- a/TwilioVideo.js
+++ b/TwilioVideo.js
@@ -129,11 +129,12 @@ export default class TwilioVideo extends Component {
   }
 
   componentWillMount() {
-    this._registerEvents()
+    this._registerEvents();
+    TWVideoModule.initializeCamera()
   }
 
   componentWillUnmount() {
-    this._unregisterEvents()
+    this._unregisterEvents();
   }
 
 

--- a/ios/TWVideoModule.m
+++ b/ios/TWVideoModule.m
@@ -68,27 +68,6 @@ RCT_EXPORT_MODULE();
 
     //previewView.translatesAutoresizingMaskIntoConstraints = NO;
     self.previewView = previewView;
-
-
-    self.localMedia = [[TVILocalMedia alloc] init];
-    self.camera = [[TVICameraCapturer alloc] init];
-    self.camera.delegate = self;
-
-    self.localVideoTrack = [self.localMedia addVideoTrack:YES
-                                                 capturer:self.camera
-                                              constraints:[self videoConstraints]
-                                                    error:nil];
-
-    self.localAudioTrack = [self.localMedia addAudioTrack:YES];
-
-    if (!self.localVideoTrack) {
-      NSLog(@"Failed to add video track");
-    } else {
-      // Attach view to video track for local preview
-      [self.localVideoTrack attach:previewView];
-    }
-
-
   }
   return self;
 }
@@ -107,6 +86,28 @@ RCT_EXPORT_MODULE();
   self.localVideoTrack = nil;
   self.videoClient = nil;
   self.room = nil;
+}
+
+RCT_EXPORT_METHOD(initializeCamera) {
+  if (self && !self.camera) {
+    self.localMedia = [[TVILocalMedia alloc] init];
+    self.camera = [[TVICameraCapturer alloc] init];
+    self.camera.delegate = self;
+
+    self.localVideoTrack = [self.localMedia addVideoTrack:YES
+                                                 capturer:self.camera
+                                              constraints:[self videoConstraints]
+                                                    error:nil];
+
+    self.localAudioTrack = [self.localMedia addAudioTrack:YES];
+
+    if (!self.localVideoTrack) {
+      NSLog(@"Failed to add video track");
+    } else {
+      // Attach view to video track for local preview
+      [self.localVideoTrack attach:previewView];
+    }
+  }
 }
 
 RCT_EXPORT_METHOD(flipCamera) {

--- a/ios/TWVideoModule.m
+++ b/ios/TWVideoModule.m
@@ -105,7 +105,9 @@ RCT_EXPORT_METHOD(initializeCamera) {
       NSLog(@"Failed to add video track");
     } else {
       // Attach view to video track for local preview
-      [self.localVideoTrack attach:previewView];
+      if (self.previewView) {
+        [self.localVideoTrack attach:self.previewView];
+      }
     }
   }
 }


### PR DESCRIPTION
Currently the local media stream is initialized in init, which means
camera permissions will typically be prompted when the app is
initialized.  In most cases, we actually want to ask only when the
component gets mounted (so that the user has proper context around
permissions).

* Move the local camera initialization out of the init method and into
a new initializeCamera method.
* Call this method in componentWillMount.