### PR TITLE
Cleanup typos in documentation and rename onCameraWasInterrumpted to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ People using a version < 1.0.1 please move to 1.0.1 since the project changed a 
 Add node package using yarn/NPM:
 
 ```shell
-yarn add https://github.com/blackuy/react-native-twilio-video-webrtc`
+yarn add https://github.com/blackuy/react-native-twilio-video-webrtc
 ```
 
 Add the plugin dependency to your Podfile, pointing at the path where NPM installed it:
@@ -50,7 +50,7 @@ To enable camera usage and microphone usage you will need to add the following e
 <key>NSCameraUsageDescription</key>
 <string>Your message to user when the camera is accessed for the first time</string>
 <key>NSMicrophoneUsageDescription</key>
-<string>Your message to user when the microsphone is accessed for the first time</string>
+<string>Your message to user when the microphone is accessed for the first time</string>
 ```
 
 ### Android
@@ -62,7 +62,7 @@ You can see the documentation [here](./docs).
 
 ## Usage
 
-We have three important component to understand:
+We have three important components to understand:
 
 ```javascript
 import {

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,14 +26,14 @@ Called when the camera has started
 onCameraDidStopRunning: Function
 ```
 
-Called when the camera has stopped runing with an error
+Called when the camera has stopped running with an error
 
 @param {{error}} The error message description
 
-#### onCameraWasInterrumpted
+#### onCameraWasInterrupted
 
 ```js
-onCameraWasInterrumpted: Function
+onCameraWasInterrupted: Function
 ```
 
 Called when the camera has been interrupted

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -24,7 +24,7 @@ static NSString* participantEnabledTrack      = @"participantEnabledTrack";
 static NSString* participantDisabledTrack     = @"participantDisabledTrack";
 
 static NSString* cameraDidStart               = @"cameraDidStart";
-static NSString* cameraWasInterrumpted        = @"cameraWasInterrumpted";
+static NSString* cameraWasInterrupted        = @"cameraWasInterrupted";
 static NSString* cameraDidStopRunning         = @"cameraDidStopRunning";
 
 
@@ -62,7 +62,7 @@ RCT_EXPORT_MODULE();
     participantDisabledTrack,
     cameraDidStopRunning,
     cameraDidStart,
-    cameraWasInterrumpted
+    cameraWasInterrupted
   ];
 }
 
@@ -169,7 +169,7 @@ RCT_EXPORT_METHOD(disconnect) {
 # pragma mark - TVICameraCapturerDelegate
 
 -(void)cameraCapturerWasInterrupted:(TVICameraCapturer *)capturer {
-  [self sendEventWithName:cameraWasInterrumpted body:nil];
+  [self sendEventWithName:cameraWasInterrupted body:nil];
 }
 
 -(void)cameraCapturerPreviewDidStart:(TVICameraCapturer *)capturer {

--- a/src/TwilioVideo.js
+++ b/src/TwilioVideo.js
@@ -93,7 +93,7 @@ export default class extends Component {
      * Called when the camera has been interrupted
      *
      */
-    onCameraWasInterrumpted: PropTypes.func,
+    onCameraWasInterrupted: PropTypes.func,
     /**
      * Called when the camera has stopped runing with an error
      *
@@ -224,8 +224,8 @@ export default class extends Component {
       this._eventEmitter.addListener('cameraDidStart', (data) => {
         if(this.props.onCameraDidStart){ this.props.onCameraDidStart(data) }
       }),
-      this._eventEmitter.addListener('cameraWasInterrumpted', (data) => {
-        if(this.props.onCameraWasInterrumpted){ this.props.onCameraWasInterrumpted(data) }
+      this._eventEmitter.addListener('cameraWasInterrupted', (data) => {
+        if(this.props.onCameraWasInterrupted){ this.props.onCameraWasInterrupted(data) }
       }),
       this._eventEmitter.addListener('cameraDidStopRunning', (data) => {
         if(this.props.onCameraDidStopRunning){ this.props.onCameraDidStopRunning(data) }


### PR DESCRIPTION
…onCameraWasInterrupted (wherever it occurs)