### PR TITLE
Use findNodeHandle on the inner view on android

### DIFF
--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -107,7 +107,7 @@ class CustomTwilioVideoView extends Component {
     switch (Platform.OS) {
       case 'android':
         UIManager.dispatchViewManagerCommand(
-          findNodeHandle(this),
+          findNodeHandle(this.refs.videoView),
           event,
           args
         );
@@ -120,6 +120,7 @@ class CustomTwilioVideoView extends Component {
   render() {
     return (
       <NativeCustomTwilioVideoView
+        ref="videoView"
         onConnected={(event) => {
           this.props.onRoomDidConnect && this.props.onRoomDidConnect(event.nativeEvent);
         }}


### PR DESCRIPTION
On android we are using findNodeHandle to get the view to send commands
to but depending on the specifics of the layout, 'this' may not refer
to what we want.