### PR TITLE
Fix android build for RN 0.47

### DIFF
--- a/android/src/main/java/com/twiliorn/library/TwilioPackage.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioPackage.java
@@ -24,7 +24,7 @@ public class TwilioPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated by RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModules is no longer present.  In order to ensure backwards
compatibility, just remove the Override tag for now.