### PR TITLE
Fix handling of android events

### DIFF
--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -118,11 +118,34 @@ class CustomTwilioVideoView extends Component {
     }
   }
 
+  buildNativeEventWrappers() {
+    const nativeEvents = [
+      'onCameraSwitched',
+      'onVideoChanged',
+      'onAudioChanged',
+      'onRoomDidConnect',
+      'onRoomDidFailToConnect',
+      'onRoomDidDisconnect',
+      'onParticipantAddedVideoTrack',
+      'onParticipantRemovedVideoTrack',
+      'onRoomParticipantDidConnect',
+      'onRoomParticipantDidDisconnect',
+    ];
+    let wrappedEvents = {};
+    nativeEvents.forEach(eventName => {
+      if (this.props[eventName]) {
+        wrappedEvents[eventName] = (data) => this.props[eventName](data.nativeEvent);
+      }
+    });
+    return wrappedEvents;
+  }
+
   render() {
     return (
       <NativeCustomTwilioVideoView
         ref="videoView"
         {...this.props}
+        {...this.buildNativeEventWrappers()}
       />
     );
   }

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -119,7 +119,7 @@ class CustomTwilioVideoView extends Component {
   }
 
   buildNativeEventWrappers() {
-    const nativeEvents = [
+    return [
       'onCameraSwitched',
       'onVideoChanged',
       'onAudioChanged',
@@ -130,14 +130,15 @@ class CustomTwilioVideoView extends Component {
       'onParticipantRemovedVideoTrack',
       'onRoomParticipantDidConnect',
       'onRoomParticipantDidDisconnect',
-    ];
-    let wrappedEvents = {};
-    nativeEvents.forEach(eventName => {
+    ].reduce((wrappedEvents, eventName) => {
       if (this.props[eventName]) {
-        wrappedEvents[eventName] = (data) => this.props[eventName](data.nativeEvent);
+        return {
+          ...wrappedEvents,
+          [eventName]: (data) => this.props[eventName](data.nativeEvent),
+        };
       }
-    });
-    return wrappedEvents;
+      return wrappedEvents;
+    }, {});
   }
 
   render() {


### PR DESCRIPTION
The way we are passing events along in the android side, the callbacks
would receive and event object.  However, the interface expects the
underlying nativeEvent (i.e. a map with the fields as on iOS), so we
need to put together simple wrappers for our events to make things
match.

Fixes #29