### PR TITLE
Fix errors when using `Object` apis with `Map`

### DIFF
--- a/Example/index.ios.js
+++ b/Example/index.ios.js
@@ -136,7 +136,12 @@ export default class Example extends Component {
   _onParticipantAddedVideoTrack = ({participant, track}) => {
     console.log("onParticipantAddedVideoTrack: ", participant, track)
 
-    this.setState({videoTracks: { ...this.state.videoTracks, [track.trackId]: { ...participant, ...track }}})
+    this.setState({
+      videoTracks: new Map([
+        ...this.state.videoTracks,
+        [track.trackId, { ...participant, ...track }]
+      ]),
+    });
   }
 
   _onParticipantRemovedVideoTrack = ({participant, track}) => {
@@ -145,7 +150,7 @@ export default class Example extends Component {
     const videoTracks = this.state.videoTracks
     videoTracks.delete(track.trackId)
 
-    this.setState({videoTracks: { ...videoTracks }})
+    this.setState({ videoTracks: new Map([ ...videoTracks ]) });
   }
 
   render() {
@@ -184,13 +189,13 @@ export default class Example extends Component {
               this.state.status === 'connected' &&
               <View style={styles.remoteGrid}>
                 {
-                  Object.keys(this.state.videoTracks).map(trackId => {
+                  Array.from(this.state.videoTracks, ([trackId, track]) => {
                     return (
                       <TwilioVideoParticipantView
                         style={styles.remoteVideo}
                         key={trackId}
                         trackIdentifier={{
-                          participantIdentity: this.state.videoTracks[trackId].identity,
+                          participantIdentity: track.identity,
                           videoTrackId: trackId
                         }}
                       />


### PR DESCRIPTION
> Error: One of the sources for assign has an enumerable key on the prototype chain. This is an edge case that we do not support. This error is a performance optimization and not spec compliant.

`Object.assign` and `Object.keys` should not be used with `Map`. I was seeing errors when trying this example on the latest RN release.