### PR TITLE
feature-screencap Add flag to TwilioVideo to use TVIScreenCapturer (iOS only)

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -31,6 +31,7 @@ static NSString* cameraDidStopRunning         = @"cameraDidStopRunning";
 @interface RCTTWVideoModule () <TVIParticipantDelegate, TVIRoomDelegate, TVICameraCapturerDelegate>
 
 @property (strong, nonatomic) TVICameraCapturer *camera;
+@property (strong, nonatomic) TVIScreenCapturer *screen;
 @property (strong, nonatomic) TVILocalVideoTrack* localVideoTrack;
 @property (strong, nonatomic) TVILocalAudioTrack* localAudioTrack;
 @property (strong, nonatomic) TVIRoom *room;
@@ -96,8 +97,13 @@ RCT_EXPORT_MODULE();
   }
 }
 
-RCT_EXPORT_METHOD(startLocalVideo) {
-  if ([TVICameraCapturer availableSources].count > 0) {
+RCT_EXPORT_METHOD(startLocalVideo:(BOOL)screenShare) {
+  if (screenShare) {
+    UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+    self.screen = [[TVIScreenCapturer alloc] initWithView:rootViewController.view];
+
+    self.localVideoTrack = [TVILocalVideoTrack trackWithCapturer:self.screen enabled:YES constraints:[self videoConstraints]];
+  } else if ([TVICameraCapturer availableSources].count > 0) {
     self.camera = [[TVICameraCapturer alloc] init];
     self.camera.delegate = self;
 

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -19,6 +19,10 @@ const { TWVideoModule } = NativeModules
 export default class extends Component {
   static propTypes = {
     /**
+     * Flag that enables screen sharing RCTRootView instead of camera capture
+     */
+    screenShare: PropTypes.bool,
+    /**
      * Called when the room has connected
      *
      * @param {{roomName, participants}}
@@ -166,7 +170,8 @@ export default class extends Component {
   }
 
   _startLocalVideo () {
-    TWVideoModule.startLocalVideo()
+    const screenShare = this.props.screenShare || false
+    TWVideoModule.startLocalVideo(screenShare)
   }
 
   _stopLocalVideo () {


### PR DESCRIPTION
Simply a flag "screenShare" passed to TwilioVideo that causes the video track to use TVIScreenCapturer instead of TVICameraCapturer.

I can take a look at having a toggle that replaces the video track in a future PR, but all I needed for my immediate project was screensharing.