### PR TITLE
[iOS] Embed video views within parent views

### DIFF
--- a/ios/RCTTWLocalVideoViewManager.m
+++ b/ios/RCTTWLocalVideoViewManager.m
@@ -18,7 +18,11 @@
 RCT_EXPORT_MODULE()
 
 - (UIView *)view {
-  return [[TVIVideoView alloc] init];
+  UIView *container = [[UIView alloc] init];
+  TVIVideoView *inner = [[TVIVideoView alloc] init];
+  inner.contentMode = UIViewContentModeScaleAspectFill;
+  [container addSubview:inner];
+  return container;
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(enabled, BOOL, TVIVideoView) {
@@ -27,9 +31,9 @@ RCT_CUSTOM_VIEW_PROPERTY(enabled, BOOL, TVIVideoView) {
     BOOL isEnabled = [RCTConvert BOOL:json];
 
     if (isEnabled) {
-      [videoModule addLocalView:view];
+      [videoModule addLocalView:view.subviews[0]];
     } else {
-      [videoModule removeLocalView:view];
+      [videoModule removeLocalView:view.subviews[0]];
     }
   }
 }

--- a/ios/RCTTWRemoteVideoViewManager.m
+++ b/ios/RCTTWRemoteVideoViewManager.m
@@ -48,7 +48,11 @@
 RCT_EXPORT_MODULE()
 
 - (UIView *)view {
-  return [[TVIVideoView alloc] init];
+  UIView *container = [[UIView alloc] init];
+  TVIVideoView *inner = [[TVIVideoView alloc] init];
+  inner.contentMode = UIViewContentModeScaleAspectFill;
+  [container addSubview:inner];
+  return container;
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(trackIdentifier, RCTTWVideoTrackIdentifier, TVIVideoView) {
@@ -56,7 +60,7 @@ RCT_CUSTOM_VIEW_PROPERTY(trackIdentifier, RCTTWVideoTrackIdentifier, TVIVideoVie
     RCTTWVideoModule *videoModule = [self.bridge moduleForName:@"TWVideoModule"];
     RCTTWVideoTrackIdentifier *id = [RCTConvert RCTTWVideoTrackIdentifier:json];
 
-    [videoModule addParticipantView:view identity:id.participantIdentity trackId:id.videoTrackId];
+    [videoModule addParticipantView:view.subviews[0] identity:id.participantIdentity trackId:id.videoTrackId];
   }
 }
 


### PR DESCRIPTION
There are some cases where react native's dynamic resizing of the views
directly causes problems.  Wrapping the views within plain UIViews
seems to solve the problem.

Additionally, this allows us to set the contentMode on the video views
to AspectFill which will replicate the behavior that was recently
merged into android.