### PR TITLE
Android multiparty support implemented by @georgewwindsor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ node_modules
 ## Build generated
 build/
 DerivedData/
-
+.idea
 ## Various settings
 *.pbxuser
 !default.pbxuser

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:design:25.3.1'
-    compile "com.twilio:video-android:1.0.1"
+    compile "com.twilio:video-android:1.3.8"
 
     compile "com.facebook.react:react-native:+"  // From node_modules
 

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -1,10 +1,10 @@
 /**
  * Component to orchestrate the Twilio Video connection and the various video
  * views.
- *
+ * <p>
  * Authors:
- *   Ralph Pina <ralph.pina@gmail.com>
- *   Jonathan Chang <slycoder@gmail.com>
+ * Ralph Pina <ralph.pina@gmail.com>
+ * Jonathan Chang <slycoder@gmail.com>
  */
 package com.twiliorn.library;
 
@@ -99,11 +99,11 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     @Nullable
     public Map<String, Integer> getCommandsMap() {
         return MapBuilder.of(
-            "connectToRoom", CONNECT_TO_ROOM,
-            "disconnect", DISCONNECT,
-            "switchCamera", SWITCH_CAMERA,
-            "toggleVideo", TOGGLE_VIDEO,
-            "toggleSound", TOGGLE_SOUND
+                "connectToRoom", CONNECT_TO_ROOM,
+                "disconnect", DISCONNECT,
+                "switchCamera", SWITCH_CAMERA,
+                "toggleVideo", TOGGLE_VIDEO,
+                "toggleSound", TOGGLE_SOUND
         );
     }
 }

--- a/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
+++ b/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
@@ -1,8 +1,8 @@
 /**
  * Wrapper component for the Twilio Video View to facilitate easier layout.
- *
+ * <p>
  * Author:
- *   Jonathan Chang <slycoder@gmail.com>
+ * Jonathan Chang <slycoder@gmail.com>
  */
 package com.twiliorn.library;
 
@@ -17,78 +17,78 @@ import com.twilio.video.VideoView;
 import org.webrtc.RendererCommon;
 
 public class RNVideoViewGroup extends ViewGroup {
-  private VideoView surfaceViewRenderer = null;
-  private int videoWidth = 0;
-  private int videoHeight = 0;
-  private final Object layoutSync = new Object();
-  private RendererCommon.ScalingType scalingType = RendererCommon.ScalingType.SCALE_ASPECT_FILL;
+    private VideoView surfaceViewRenderer = null;
+    private int videoWidth = 0;
+    private int videoHeight = 0;
+    private final Object layoutSync = new Object();
+    private RendererCommon.ScalingType scalingType = RendererCommon.ScalingType.SCALE_ASPECT_FILL;
 
 
-  public RNVideoViewGroup(Context context) {
-    super(context);
+    public RNVideoViewGroup(Context context) {
+        super(context);
 
-    surfaceViewRenderer = new VideoView(context);
-    surfaceViewRenderer.setVideoScaleType(VideoScaleType.ASPECT_FILL);
-    addView(surfaceViewRenderer);
-    surfaceViewRenderer.setListener(
-        new VideoRenderer.Listener() {
-          @Override
-          public void onFirstFrame() {
+        surfaceViewRenderer = new VideoView(context);
+        surfaceViewRenderer.setVideoScaleType(VideoScaleType.ASPECT_FILL);
+        addView(surfaceViewRenderer);
+        surfaceViewRenderer.setListener(
+                new VideoRenderer.Listener() {
+                    @Override
+                    public void onFirstFrame() {
 
-          }
+                    }
 
-          @Override
-          public void onFrameDimensionsChanged(int vw, int vh, int rotation) {
-            synchronized (layoutSync) {
-              videoHeight = vh;
-              videoWidth = vw;
-              RNVideoViewGroup.this.forceLayout();
-            }
-          }
-        }
-    );
-  }
-
-  public VideoView getSurfaceViewRenderer() {
-    return surfaceViewRenderer;
-  }
-
-  public void setScalingType(RendererCommon.ScalingType scalingType) {
-    this.scalingType = scalingType;
-  }
-
-  @Override
-  protected void onLayout(boolean changed, int l, int t, int r, int b) {
-    int height = b - t;
-    int width = r - l;
-    if (height == 0 || width == 0) {
-      l = t = r = b = 0;
-    } else {
-      int videoHeight;
-      int videoWidth;
-      synchronized (layoutSync) {
-        videoHeight = this.videoHeight;
-        videoWidth = this.videoWidth;
-      }
-
-      if (videoHeight == 0 || videoWidth == 0) {
-        // These are Twilio defaults.
-        videoHeight = 480;
-        videoWidth = 640;
-      }
-
-      Point displaySize = RendererCommon.getDisplaySize(
-          this.scalingType,
-          videoWidth / (float) videoHeight,
-          width,
-          height
-      );
-
-      l = (width - displaySize.x) / 2;
-      t = (height - displaySize.y) / 2;
-      r = l + displaySize.x;
-      b = t + displaySize.y;
+                    @Override
+                    public void onFrameDimensionsChanged(int vw, int vh, int rotation) {
+                        synchronized (layoutSync) {
+                            videoHeight = vh;
+                            videoWidth = vw;
+                            RNVideoViewGroup.this.forceLayout();
+                        }
+                    }
+                }
+        );
     }
-    surfaceViewRenderer.layout(l, t, r, b);
-  }
+
+    public VideoView getSurfaceViewRenderer() {
+        return surfaceViewRenderer;
+    }
+
+    public void setScalingType(RendererCommon.ScalingType scalingType) {
+        this.scalingType = scalingType;
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        int height = b - t;
+        int width = r - l;
+        if (height == 0 || width == 0) {
+            l = t = r = b = 0;
+        } else {
+            int videoHeight;
+            int videoWidth;
+            synchronized (layoutSync) {
+                videoHeight = this.videoHeight;
+                videoWidth = this.videoWidth;
+            }
+
+            if (videoHeight == 0 || videoWidth == 0) {
+                // These are Twilio defaults.
+                videoHeight = 480;
+                videoWidth = 640;
+            }
+
+            Point displaySize = RendererCommon.getDisplaySize(
+                    this.scalingType,
+                    videoWidth / (float) videoHeight,
+                    width,
+                    height
+            );
+
+            l = (width - displaySize.x) / 2;
+            t = (height - displaySize.y) / 2;
+            r = l + displaySize.x;
+            b = t + displaySize.y;
+        }
+        surfaceViewRenderer.layout(l, t, r, b);
+    }
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioPackage.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioPackage.java
@@ -1,9 +1,9 @@
 /**
  * Twilio Video for React Native.
- *
+ * <p>
  * Authors:
- *   Ralph Pina <ralph.pina@gmail.com>
- *   Jonathan Chang <slycoder@gmail.com>
+ * Ralph Pina <ralph.pina@gmail.com>
+ * Jonathan Chang <slycoder@gmail.com>
  */
 
 package com.twiliorn.library;
@@ -32,9 +32,9 @@ public class TwilioPackage implements ReactPackage {
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
-            new CustomTwilioVideoViewManager(),
-            new TwilioRemotePreviewManager(),
-            new TwilioVideoPreviewManager()
+                new CustomTwilioVideoViewManager(),
+                new TwilioRemotePreviewManager(),
+                new TwilioVideoPreviewManager()
         );
     }
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
@@ -1,20 +1,32 @@
 /**
  * Component for Twilio Video participant views.
- *
+ * <p>
  * Authors:
- *   Jonathan Chang <slycoder@gmail.com>
+ * Jonathan Chang <slycoder@gmail.com>
  */
 
 package com.twiliorn.library;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import android.util.Log;
+
 
 public class TwilioRemotePreview extends RNVideoViewGroup {
 
     private static final String TAG = "TwilioRemotePreview";
 
-    public TwilioRemotePreview(Context context) {
+
+    public TwilioRemotePreview(Context context, String trackId) {
         super(context);
-        CustomTwilioVideoView.registerPrimaryVideoView(this.getSurfaceViewRenderer());
+        Log.i("CustomTwilioVideoView", "Remote Prview Construct");
+        Log.i("CustomTwilioVideoView", trackId);
+
+
+        CustomTwilioVideoView.registerPrimaryVideoView(this.getSurfaceViewRenderer(), trackId);
     }
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
@@ -1,27 +1,42 @@
 /**
  * Component for Twilio Video participant views.
- *
+ * <p>
  * Authors:
- *   Jonathan Chang <slycoder@gmail.com>
+ * Jonathan Chang <slycoder@gmail.com>
  */
 
 package com.twiliorn.library;
 
+import android.support.annotation.Nullable;
+import android.util.Log;
+
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-
+import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class TwilioRemotePreviewManager extends SimpleViewManager<TwilioRemotePreview> {
 
     public static final String REACT_CLASS = "RNTwilioRemotePreview";
+    public String myTrackId = "";
 
     @Override
     public String getName() {
         return REACT_CLASS;
     }
 
+
+    @ReactProp(name = "trackId")
+    public void setTrackId(TwilioRemotePreview view, @Nullable String trackId) {
+
+        Log.i("CustomTwilioVideoView", "Initialize Twilio REMOTEEEEEEEEE");
+        Log.i("CustomTwilioVideoView", trackId);
+        myTrackId = trackId;
+        CustomTwilioVideoView.registerPrimaryVideoView(view.getSurfaceViewRenderer(), trackId);
+    }
+
+
     @Override
     protected TwilioRemotePreview createViewInstance(ThemedReactContext reactContext) {
-        return new TwilioRemotePreview(reactContext);
+        return new TwilioRemotePreview(reactContext, myTrackId);
     }
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
@@ -1,8 +1,8 @@
 /**
  * Component for Twilio Video local views.
- *
+ * <p>
  * Authors:
- *   Jonathan Chang <slycoder@gmail.com>
+ * Jonathan Chang <slycoder@gmail.com>
  */
 
 package com.twiliorn.library;

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
@@ -1,8 +1,8 @@
 /**
  * Component for Twilio Video local views.
- *
+ * <p>
  * Authors:
- *   Jonathan Chang <slycoder@gmail.com>
+ * Jonathan Chang <slycoder@gmail.com>
  */
 
 package com.twiliorn.library;

--- a/src/TwilioVideoParticipantView.android.js
+++ b/src/TwilioVideoParticipantView.android.js
@@ -5,25 +5,27 @@
  *   Jonathan Chang <slycoder@gmail.com>
  */
 
-import {
-  requireNativeComponent,
-  View
-} from 'react-native'
+import { requireNativeComponent } from 'react-native'
+import PropTypes from 'prop-types'
 import React from 'react'
 
-const propTypes = {
-  ...View.propTypes
-}
-
 class TwilioRemotePreview extends React.Component {
+  static propTypes = {
+    trackId: PropTypes.string,
+    renderToHardwareTextureAndroid: PropTypes.string,
+    onLayout: PropTypes.string,
+    accessibilityLiveRegion: PropTypes.string,
+    accessibilityComponentType: PropTypes.string,
+    importantForAccessibility: PropTypes.string,
+    accessibilityLabel: PropTypes.string,
+    nativeID: PropTypes.string,
+    testID: PropTypes.string
+  }
+
   render () {
-    return (
-      <NativeTwilioRemotePreview {...this.props} />
-    )
+    return <NativeTwilioRemotePreview {...this.props} />
   }
 }
-
-TwilioRemotePreview.propTypes = propTypes
 
 const NativeTwilioRemotePreview = requireNativeComponent(
   'RNTwilioRemotePreview',


### PR DESCRIPTION
This merge request was initiated by @georgewwindsor and I simply squashed the commits.. Also, added a small change to TwilioVideoParticipantView.android.js where the trackId prop was required

Below is the original message from #74 

The existing android code uses a single "participantTrack" to contain incoming tracks. This causes 2 problems:

1. current android code is only 1-to-1.
2. the current android code gets" disconnected" from the server because it screws up the bitrate when you replace the video with the next incoming person.

I have modified the library to allow multiple android users on stage at once. This required routing the trackId through the android component, which was previously not being done.

i additionally updated the android TWILIO dependency from 1.0.1 to 1.3.8 because...well it was just severely outdated. It now matches the current IOS.

Please Review and test on 3+ devices, one of the being android. if you have any suggestions or request, please let me know and i will be happy to make the changes.