### PR TITLE
iOS getStats

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -23,6 +23,7 @@ static NSString* participantRemovedAudioTrack = @"participantRemovedAudioTrack";
 static NSString* participantEnabledTrack      = @"participantEnabledTrack";
 static NSString* participantDisabledTrack     = @"participantDisabledTrack";
 
+static NSString* gotStats               = @"gotStats";
 static NSString* cameraDidStart               = @"cameraDidStart";
 static NSString* cameraWasInterrupted        = @"cameraWasInterrupted";
 static NSString* cameraDidStopRunning         = @"cameraDidStopRunning";
@@ -63,7 +64,8 @@ RCT_EXPORT_MODULE();
     participantDisabledTrack,
     cameraDidStopRunning,
     cameraDidStart,
-    cameraWasInterrupted
+    cameraWasInterrupted,
+    gotStats
   ];
 }
 
@@ -96,18 +98,302 @@ RCT_EXPORT_MODULE();
     }
   }
 }
+RCT_EXPORT_METHOD(getStats) {
+    NSLog(@"GET STATS");
+    [self.room getStatsWithBlock:^(NSArray<TVIStatsReport *> * _Nonnull statsReports) {
+        NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
+        f.numberStyle = NSNumberFormatterDecimalStyle;
 
-RCT_EXPORT_METHOD(startLocalVideo:(BOOL)screenShare) {
+
+        NSMutableDictionary *condensedStats = [[NSMutableDictionary alloc]initWithCapacity:10];
+        NSMutableDictionary *incomingAudioTracks = [[NSMutableDictionary alloc]initWithCapacity:10];
+        NSMutableDictionary *incomingVideoTracks = [[NSMutableDictionary alloc]initWithCapacity:10];
+        NSMutableDictionary *localVideoTracks = [[NSMutableDictionary alloc]initWithCapacity:10];
+        NSMutableDictionary *localAudioTracks = [[NSMutableDictionary alloc]initWithCapacity:10];
+
+               for (id statReport in statsReports) {
+                   if([statReport peerConnectionId]){
+                   NSLog(@"%@",[statReport peerConnectionId]);
+                       [condensedStats setObject:[statReport peerConnectionId] forKey:@"peerConnectionId"];
+                   }
+
+
+
+                   if([statReport localAudioTrackStats]){
+                       NSArray *audioTracks = [statReport localAudioTrackStats];
+                       for (id audioTrack in audioTracks) {
+                           NSMutableDictionary *outgoingTrack= [[NSMutableDictionary alloc]initWithCapacity:10];
+                           NSString *trackId = nil;
+                           if([audioTrack roundTripTime]){
+                               NSNumber *roundTripTime= [f  numberFromString:[NSString stringWithFormat:@"%llu", [audioTrack roundTripTime]]];
+                               [outgoingTrack setObject:roundTripTime forKey:@"roundTripTime"];
+                           }
+                           if([audioTrack audioLevel]){
+                               NSNumber *audioLevel= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[audioTrack audioLevel]]];
+                               [outgoingTrack setObject:audioLevel forKey:@"audioLevel"];
+                           }
+                           if([audioTrack jitter]){
+                               NSNumber *jitter= [f  numberFromString:[NSString stringWithFormat:@"%lu", [audioTrack jitter]]];
+                               [outgoingTrack setObject:jitter forKey:@"jitter"];
+                           }
+                           if([audioTrack codec]){
+                               NSString *codec = [NSString stringWithFormat:@"%@", [audioTrack codec]];
+                               [outgoingTrack setObject:codec forKey:@"codec"];
+                           }
+
+                           if([audioTrack ssrc]){
+                               NSNumber *ssrc= [f  numberFromString:[NSString stringWithFormat:@"%lu", [audioTrack jitter]]];
+                               [outgoingTrack setObject:ssrc forKey:@"ssrc"];
+                           }
+                           if([audioTrack trackId]){
+                               trackId = [NSString stringWithFormat:@"%@", [audioTrack trackId]];
+                               [outgoingTrack setObject:trackId forKey:@"trackId"];
+                           }
+
+                           if([audioTrack packetsSent]){
+                               NSNumber *packetsSent= [f  numberFromString:[NSString stringWithFormat:@"%lu", [audioTrack packetsSent]]];
+                               [outgoingTrack setObject:packetsSent forKey:@"packetsSent"];
+                           }
+
+                           if([audioTrack packetsLost]){
+                               NSNumber *packetsLost= [f  numberFromString:[NSString stringWithFormat:@"%lu", [audioTrack packetsLost]]];
+                               [outgoingTrack setObject:packetsLost forKey:@"packetsLost"];
+                           }
+                           if([audioTrack valueForKey:@"timestamp"]){
+                               NSNumber *timestamp= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[audioTrack valueForKey:@"timestamp"]]];
+                               [outgoingTrack setObject:timestamp forKey:@"timestamp"];
+                           }
+
+                           [localAudioTracks setObject:outgoingTrack forKey:trackId];
+
+
+                       }
+                   }
+
+
+
+
+
+
+                   if([statReport localVideoTrackStats]){
+                       NSArray *videoTracks = [statReport localVideoTrackStats];
+                       for (id videoTrack in videoTracks) {
+
+                           NSMutableDictionary *outgoingTrack= [[NSMutableDictionary alloc]initWithCapacity:10];
+                           NSString *trackId = nil;
+
+
+
+                           if([videoTrack bytesSent]){
+                               NSNumber *bytesSent= [f  numberFromString:[NSString stringWithFormat:@"%llu", [videoTrack bytesSent]]];
+
+                               [outgoingTrack setObject:bytesSent forKey:@"bytesSent"];
+                           }
+                           if([videoTrack roundTripTime]){
+                               NSNumber *roundTripTime= [f  numberFromString:[NSString stringWithFormat:@"%llu", [videoTrack roundTripTime]]];
+                                [outgoingTrack setObject:roundTripTime forKey:@"roundTripTime"];
+                           }
+                           if([videoTrack codec]){
+                               NSString *codec = [NSString stringWithFormat:@"%@", [videoTrack codec]];
+                               [outgoingTrack setObject:codec forKey:@"codec"];
+                           }
+                           if([videoTrack frameRate]){
+                                  NSNumber *frameRate= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack frameRate]]];
+
+                               [outgoingTrack setObject:frameRate forKey:@"frameRate"];
+                           }
+                           if([videoTrack trackId]){
+                               trackId = [NSString stringWithFormat:@"%@", [videoTrack trackId]];
+                               [outgoingTrack setObject:trackId forKey:@"trackId"];
+                           }
+
+                           if([videoTrack packetsSent]){
+                               NSNumber *packetsSent= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack packetsSent]]];
+                               [outgoingTrack setObject:packetsSent forKey:@"packetsSent"];
+                           }
+
+                           if([videoTrack packetsLost]){
+                               NSNumber *packetsLost= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack packetsLost]]];
+                               [outgoingTrack setObject:packetsLost forKey:@"packetsLost"];
+                           }
+
+                           if([videoTrack valueForKey:@"dimensions"]){
+                               CMVideoDimensions dimensions =  [videoTrack dimensions];
+
+                               NSNumber *height= [f  numberFromString:[NSString stringWithFormat:@"%d", dimensions.height]];
+
+                               [outgoingTrack setObject:height forKey:@"height"];
+
+                               NSNumber *width= [f  numberFromString:[NSString stringWithFormat:@"%d", dimensions.width]];
+
+                               [outgoingTrack setObject:width forKey:@"width"];
+
+                           }
+
+                           if([videoTrack valueForKey:@"timestamp"]){
+
+                               NSNumber *timestamp= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack valueForKey:@"timestamp"]]];
+
+                               [outgoingTrack setObject:timestamp forKey:@"timestamp"];
+                           }
+
+                           [localVideoTracks setObject:outgoingTrack forKey:trackId];
+
+
+                       }
+                   }
+
+
+                   if([statReport audioTrackStats]){
+                       NSArray *audioTracks = [statReport audioTrackStats];
+                       for (id audioTrack in audioTracks) {
+                           NSString *trackId = nil;
+                           NSMutableDictionary *incomingTrack= [[NSMutableDictionary alloc]initWithCapacity:10];
+
+                           if([audioTrack bytesReceived]){
+                               NSNumber *bytesReceived= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[audioTrack bytesReceived]]];
+
+                               [incomingTrack setObject:bytesReceived forKey:@"bytesReceived"];
+                           }
+                           if([audioTrack audioLevel]){
+                               NSNumber *audioLevel= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[audioTrack audioLevel]]];
+                               [incomingTrack setObject:audioLevel forKey:@"audioLevel"];
+                           }
+                           if([audioTrack jitter]){
+                               NSNumber *jitter= [f  numberFromString:[NSString stringWithFormat:@"%lu", [audioTrack jitter]]];
+                               [incomingTrack setObject:jitter forKey:@"jitter"];
+                           }
+                           if([audioTrack codec]){
+                               NSString *codec = [NSString stringWithFormat:@"%@", [audioTrack codec]];
+                               [incomingTrack setObject:codec forKey:@"codec"];
+                           }
+
+                           if([audioTrack ssrc]){
+                               NSNumber *ssrc= [f  numberFromString:[NSString stringWithFormat:@"%lu", [audioTrack jitter]]];
+                               [incomingTrack setObject:ssrc forKey:@"ssrc"];
+                           }
+                           if([audioTrack trackId]){
+                               trackId = [NSString stringWithFormat:@"%@", [audioTrack trackId]];
+                               [incomingTrack setObject:trackId forKey:@"trackId"];
+                           }
+
+                           if([audioTrack packetsReceived]){
+                               NSNumber *packetsReceived= [f  numberFromString:[NSString stringWithFormat:@"%lu", [audioTrack packetsReceived]]];
+                               [incomingTrack setObject:packetsReceived forKey:@"packetsSent"];
+                           }
+
+                           if([audioTrack packetsLost]){
+                               NSNumber *packetsLost= [f  numberFromString:[NSString stringWithFormat:@"%lu", [audioTrack packetsLost]]];
+                               [incomingTrack setObject:packetsLost forKey:@"packetsLost"];
+                           }
+                           if([audioTrack valueForKey:@"timestamp"]){
+                               NSNumber *timestamp= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[audioTrack valueForKey:@"timestamp"]]];
+                               [incomingTrack setObject:timestamp forKey:@"timestamp"];
+                           }
+
+
+
+
+
+
+                           [incomingAudioTracks setObject:incomingTrack forKey:trackId];
+
+                       }
+                   }
+
+
+
+                   if([statReport videoTrackStats]){
+                       NSArray *videoStats = [statReport videoTrackStats];
+                       for (id videoTrack in videoStats) {
+                           NSString *trackId = nil;
+                           NSMutableDictionary *incomingTrack= [[NSMutableDictionary alloc]initWithCapacity:10];
+
+
+                           if([videoTrack bytesReceived]){
+                               NSNumber *bytesReceived= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack bytesReceived]]];
+
+                              [incomingTrack setObject:bytesReceived forKey:@"bytesReceived"];
+                           }
+
+                           if([videoTrack codec]){
+                               NSString *codec = [NSString stringWithFormat:@"%@", [videoTrack codec]];
+                               [incomingTrack setObject:codec forKey:@"codec"];
+                           }
+                           if([videoTrack frameRate]){
+                               NSNumber *frameRate= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack frameRate]]];
+
+                               [incomingTrack setObject:frameRate forKey:@"frameRate"];
+                           }
+                           if([videoTrack trackId]){
+                               trackId = [NSString stringWithFormat:@"%@", [videoTrack trackId]];
+                               [incomingTrack setObject:trackId forKey:@"trackId"];
+                           }
+
+                           if([videoTrack packetsReceived]){
+                               NSNumber *packetsReceived= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack packetsReceived]]];
+                               [incomingTrack setObject:packetsReceived forKey:@"packetsReceived"];
+                           }
+
+                           if([videoTrack packetsLost]){
+
+                               NSNumber *packetsLost= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack packetsLost]]];
+                               [incomingTrack setObject:packetsLost forKey:@"packetsLost"];
+                           }
+
+                           if([videoTrack valueForKey:@"dimensions"]){
+                               CMVideoDimensions dimensions =  [videoTrack dimensions];
+
+                               NSNumber *height= [f  numberFromString:[NSString stringWithFormat:@"%d", dimensions.height]];
+
+                               [incomingTrack setObject:height forKey:@"height"];
+
+                               NSNumber *width= [f  numberFromString:[NSString stringWithFormat:@"%d", dimensions.width]];
+
+                               [incomingTrack setObject:width forKey:@"width"];
+
+                           }
+
+                           if([videoTrack valueForKey:@"timestamp"]){
+
+                               NSNumber *timestamp= [f  numberFromString:[NSString stringWithFormat:@"%lu", (unsigned long)[videoTrack valueForKey:@"timestamp"]]];
+
+                               [incomingTrack setObject:timestamp forKey:@"timestamp"];
+                           }
+
+
+
+
+                           [incomingVideoTracks setObject:incomingTrack forKey:trackId];
+
+                       }
+                   }
+
+
+               }
+        [condensedStats setObject:incomingVideoTracks forKey:@"remoteVideoTracks"];
+        [condensedStats setObject:incomingAudioTracks forKey:@"remoteAudioTracks"];
+
+        [condensedStats setObject:localVideoTracks forKey:@"localVideoTracks"];
+        [condensedStats setObject:localAudioTracks forKey:@"localAudioTracks"];
+
+
+        [self sendEventWithName:gotStats body:condensedStats];
+
+    }];
+}
+
+RCT_EXPORT_METHOD(startLocalVideo:(BOOL)screenShare constraints:(NSDictionary *)constraints) {
   if (screenShare) {
     UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
     self.screen = [[TVIScreenCapturer alloc] initWithView:rootViewController.view];
 
-    self.localVideoTrack = [TVILocalVideoTrack trackWithCapturer:self.screen enabled:YES constraints:[self videoConstraints]];
+    self.localVideoTrack = [TVILocalVideoTrack trackWithCapturer:self.screen enabled:YES constraints:[self videoConstraints:constraints]];
   } else if ([TVICameraCapturer availableSources].count > 0) {
     self.camera = [[TVICameraCapturer alloc] init];
     self.camera.delegate = self;
 
-    self.localVideoTrack = [TVILocalVideoTrack trackWithCapturer:self.camera enabled:YES constraints:[self videoConstraints]];
+    self.localVideoTrack = [TVILocalVideoTrack trackWithCapturer:self.camera enabled:YES constraints:[self videoConstraints:constraints]];
   }
 }
 
@@ -177,13 +463,52 @@ RCT_EXPORT_METHOD(disconnect) {
   [self.room disconnect];
 }
 
--(TVIVideoConstraints*) videoConstraints {
+
+
+-(TVIVideoConstraints*) videoConstraints:(NSDictionary *)constraints {
   return [TVIVideoConstraints constraintsWithBlock:^(TVIVideoConstraintsBuilder *builder) {
-    builder.minSize = TVIVideoConstraintsSize960x540;
-    builder.maxSize = TVIVideoConstraintsSize1280x720;
-    builder.aspectRatio = TVIAspectRatio16x9;
-    builder.minFrameRate = TVIVideoConstraintsFrameRateNone;
-    builder.maxFrameRate = TVIVideoConstraintsFrameRateNone;
+    builder.minSize = TVIVideoConstraintsSize352x288;
+    builder.maxSize = TVIVideoConstraintsSize352x288;
+    builder.aspectRatio = TVIAspectRatio11x9;
+    builder.minFrameRate = TVIVideoConstraintsFrameRate10;
+    builder.maxFrameRate = TVIVideoConstraintsFrameRate15;
+  }];
+}
+
+
+
+
+-(TVIVideoConstraints*) old_videoConstraints:(NSDictionary *)constraints {
+  return [TVIVideoConstraints constraintsWithBlock:^(TVIVideoConstraintsBuilder *builder) {
+    NSString *aspectRatio = constraints[@"aspectRatio"];
+    int32_t minWidth = [constraints[@"minWidth"] intValue];
+    int32_t maxWidth = [constraints[@"maxWidth"] intValue];
+    NSUInteger minFrameRate = [constraints[@"minFrameRate"] intValue];
+    NSUInteger maxFrameRate = [constraints[@"maxFrameRate"] intValue];
+
+    CMVideoDimensions minDimensions;
+    minDimensions.width = minWidth;
+    minDimensions.height = [aspectRatio isEqualToString:@"4:3"]
+      ? minWidth * (3 / 4)
+      : minWidth * (9 / 16);
+
+    CMVideoDimensions maxDimensions;
+    maxDimensions.width = maxWidth;
+    maxDimensions.height = [aspectRatio isEqualToString:@"4:3"]
+      ? maxWidth * (3 / 4)
+      : maxWidth * (9 / 16);
+
+    builder.minSize = minDimensions;
+    builder.maxSize = maxDimensions;
+    builder.aspectRatio = [aspectRatio isEqualToString:@"4:3"]
+      ? TVIAspectRatio4x3
+      : TVIAspectRatio16x9;
+    builder.minFrameRate = minFrameRate == 0
+      ? TVIVideoConstraintsFrameRateNone
+      : minFrameRate;
+    builder.maxFrameRate = maxFrameRate == 0
+      ? TVIVideoConstraintsFrameRateNone
+      : maxFrameRate;
   }];
 }
 

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -104,7 +104,25 @@ export default class extends Component {
      * @param {{error}} The error message description
      */
     onCameraDidStopRunning: PropTypes.func,
+    /**
+     * Constraints for _startLocalVideo()
+     *
+     */
+
+    onStatsReceived: PropTypes.func,
+
+    constraints: PropTypes.object,
     ...View.propTypes
+  }
+
+  static defaultProps = {
+    constraints: {
+      aspectRatio: '16:9',
+      minWidth: 960,
+      maxWidth: 1280,
+      minFrameRate: 0,
+      maxFrameRate: 0
+    }
   }
 
   constructor (props) {
@@ -169,9 +187,14 @@ export default class extends Component {
     TWVideoModule.disconnect()
   }
 
+    getStats () {
+        TWVideoModule.getStats();
+    }
+
   _startLocalVideo () {
     const screenShare = this.props.screenShare || false
-    TWVideoModule.startLocalVideo(screenShare)
+    const constraints = this.props.constraints || false
+    TWVideoModule.startLocalVideo(screenShare, constraints)
   }
 
   _stopLocalVideo () {
@@ -234,7 +257,10 @@ export default class extends Component {
       }),
       this._eventEmitter.addListener('cameraDidStopRunning', (data) => {
         if (this.props.onCameraDidStopRunning) { this.props.onCameraDidStopRunning(data) }
-      })
+      }),
+        this._eventEmitter.addListener('gotStats', (data) => {
+            if (this.props.onStatsReceived) { this.props.onStatsReceived(data) }
+        }),
     ]
   }
 

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -187,9 +187,9 @@ export default class extends Component {
     TWVideoModule.disconnect()
   }
 
-    getStats () {
-        TWVideoModule.getStats();
-    }
+  getStats () {
+    TWVideoModule.getStats()
+  }
 
   _startLocalVideo () {
     const screenShare = this.props.screenShare || false
@@ -258,9 +258,9 @@ export default class extends Component {
       this._eventEmitter.addListener('cameraDidStopRunning', (data) => {
         if (this.props.onCameraDidStopRunning) { this.props.onCameraDidStopRunning(data) }
       }),
-        this._eventEmitter.addListener('gotStats', (data) => {
-            if (this.props.onStatsReceived) { this.props.onStatsReceived(data) }
-        }),
+      this._eventEmitter.addListener('gotStats', (data) => {
+        if (this.props.onStatsReceived) { this.props.onStatsReceived(data) }
+      })
     ]
   }
 


### PR DESCRIPTION
The purpose of this commit is to provide getStats for IOS. This was necessary to determine the actual bitrates, video quality etc being sent and received. I was able to determine that it dosnt matter what constraints you send, twilio will dynamically downgrade them. I have modified them to the low setting that matches what twilio will do to your stream. This is useful because it causes less audio delay because it is not being reduced in quality, and thus provides a smoother experience.

The "getstats. function is called by "this.refs.twilioVideo.getStats()", and attaching a callback at onStatsReceived property.

    <TwilioVideo
        ref={'twilioVideo'}
        onRoomDidConnect={this._roomConnected}
        onRoomDidDisconnect={this._roomDisconnected}
        onRoomDidFailToConnect={this._roomFailedToConnect}
        onParticipantAddedVideoTrack={this._userAddedVideoTrack}
        onParticipantRemovedVideoTrack={this._userRemovedVideoTrack}
        onRoomParticipantDidDisconnect={this._userDisconnected}
        onStatsReceived={this._gotStats}

      />


so for example, in your "_roomConnected" function, you could do something like.

setInterval(this.refs.twilioVideo.getStats,10000) 

to get the video stats every 10 seconds.



The only piece of of the getstats not being parsed are the candidate pairs, which in the case of twilio are irrelevant because you have no control over them.

@bilby91 @slycoder 