### PR TITLE
Enable use without adding to Podfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Global
+.DS_Store
+
 # Node
 node_modules
 
@@ -23,6 +26,7 @@ xcuserdata/
 ## Other
 *.moved-aside
 *.xcuserstate
+project.xcworkspace
 
 ## Obj-C/Swift specific
 *.hmap

--- a/README.md
+++ b/README.md
@@ -23,17 +23,10 @@ Add node package using yarn/NPM:
 yarn add https://github.com/blackuy/react-native-twilio-video-webrtc
 ```
 
-Add the plugin dependency to your Podfile, pointing at the path where NPM installed it:
+Add the Twilio dependency to your Podfile:
 
 ```ruby
-pod 'react-native-twilio-video-webrtc', path: '../node_modules/react-native-twilio-video-webrtc'
-```
-
-You will need to point your React code the path where NPM installed it too. If you didn't do it add this to your Pofile:
-
-```ruby
-pod 'Yoga', path: '../node_modules/react-native/ReactCommon/yoga/Yoga.podspec'
-pod 'React', path: '../node_modules/react-native'
+pod 'TwilioVideo'
 ```
 
 Install Pods:
@@ -41,6 +34,14 @@ Install Pods:
 ```shell
 pod install
 ```
+
+Add the XCode project to your own XCode project's "Libraries" directory from:
+
+```
+node_modules/react-native-twilio-video-webrtc/ios/RNTwilioVideoWebRTC.xcodeproj
+```
+
+Add `libRNTwilioVideoWebRTC.a` to your XCode project target's "Linked Frameworks and Libraries"
 
 ### Permissions
 

--- a/ios/RCTTWLocalVideoViewManager.h
+++ b/ios/RCTTWLocalVideoViewManager.h
@@ -6,8 +6,7 @@
 //
 //
 
-#import "UIView+React.h"
-
+#import <React/UIView+React.h>
 #import <React/RCTViewManager.h>
 
 @interface RCTTWLocalVideoViewManager : RCTViewManager

--- a/ios/RNTwilioVideoWebRTC.xcodeproj/project.pbxproj
+++ b/ios/RNTwilioVideoWebRTC.xcodeproj/project.pbxproj
@@ -1,0 +1,341 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		73814A34203776CD00E8C67D /* RCTTWLocalVideoViewManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 738F9D69203760FF00058972 /* RCTTWLocalVideoViewManager.h */; };
+		73814A35203776CD00E8C67D /* RCTTWRemoteVideoViewManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 738F9D6A203760FF00058972 /* RCTTWRemoteVideoViewManager.h */; };
+		73814A36203776CD00E8C67D /* RCTTWSerializable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 738F9D65203760FF00058972 /* RCTTWSerializable.h */; };
+		73814A37203776CD00E8C67D /* RCTTWVideoModule.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 738F9D63203760FF00058972 /* RCTTWVideoModule.h */; };
+		738F9D6B203760FF00058972 /* RCTTWSerializable.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D64203760FF00058972 /* RCTTWSerializable.m */; };
+		738F9D6C203760FF00058972 /* RCTTWRemoteVideoViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D66203760FF00058972 /* RCTTWRemoteVideoViewManager.m */; };
+		738F9D6D203760FF00058972 /* RCTTWLocalVideoViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D67203760FF00058972 /* RCTTWLocalVideoViewManager.m */; };
+		738F9D6E203760FF00058972 /* RCTTWVideoModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 738F9D68203760FF00058972 /* RCTTWVideoModule.m */; };
+		73AC89CA20377EA700038475 /* TwilioVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73AC89C920377EA700038475 /* TwilioVideo.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		738F9D532037604000058972 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				73814A34203776CD00E8C67D /* RCTTWLocalVideoViewManager.h in CopyFiles */,
+				73814A35203776CD00E8C67D /* RCTTWRemoteVideoViewManager.h in CopyFiles */,
+				73814A36203776CD00E8C67D /* RCTTWSerializable.h in CopyFiles */,
+				73814A37203776CD00E8C67D /* RCTTWVideoModule.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		738F9D552037604000058972 /* libRNTwilioVideoWebRTC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNTwilioVideoWebRTC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		738F9D63203760FF00058972 /* RCTTWVideoModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTWVideoModule.h; sourceTree = SOURCE_ROOT; };
+		738F9D64203760FF00058972 /* RCTTWSerializable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTWSerializable.m; sourceTree = SOURCE_ROOT; };
+		738F9D65203760FF00058972 /* RCTTWSerializable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTWSerializable.h; sourceTree = SOURCE_ROOT; };
+		738F9D66203760FF00058972 /* RCTTWRemoteVideoViewManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTWRemoteVideoViewManager.m; sourceTree = SOURCE_ROOT; };
+		738F9D67203760FF00058972 /* RCTTWLocalVideoViewManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTWLocalVideoViewManager.m; sourceTree = SOURCE_ROOT; };
+		738F9D68203760FF00058972 /* RCTTWVideoModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTWVideoModule.m; sourceTree = SOURCE_ROOT; };
+		738F9D69203760FF00058972 /* RCTTWLocalVideoViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTWLocalVideoViewManager.h; sourceTree = SOURCE_ROOT; };
+		738F9D6A203760FF00058972 /* RCTTWRemoteVideoViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTWRemoteVideoViewManager.h; sourceTree = SOURCE_ROOT; };
+		73AC89C920377EA700038475 /* TwilioVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = TwilioVideo.framework; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		738F9D522037604000058972 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				73AC89CA20377EA700038475 /* TwilioVideo.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		738F9D4C2037604000058972 = {
+			isa = PBXGroup;
+			children = (
+				738F9D572037604000058972 /* RNTwilioVideoWebRTC */,
+				738F9D562037604000058972 /* Products */,
+				73C838D4203766CB00DAFEE1 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		738F9D562037604000058972 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				738F9D552037604000058972 /* libRNTwilioVideoWebRTC.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		738F9D572037604000058972 /* RNTwilioVideoWebRTC */ = {
+			isa = PBXGroup;
+			children = (
+				738F9D69203760FF00058972 /* RCTTWLocalVideoViewManager.h */,
+				738F9D67203760FF00058972 /* RCTTWLocalVideoViewManager.m */,
+				738F9D6A203760FF00058972 /* RCTTWRemoteVideoViewManager.h */,
+				738F9D66203760FF00058972 /* RCTTWRemoteVideoViewManager.m */,
+				738F9D65203760FF00058972 /* RCTTWSerializable.h */,
+				738F9D64203760FF00058972 /* RCTTWSerializable.m */,
+				738F9D63203760FF00058972 /* RCTTWVideoModule.h */,
+				738F9D68203760FF00058972 /* RCTTWVideoModule.m */,
+			);
+			name = RNTwilioVideoWebRTC;
+			sourceTree = "<group>";
+		};
+		73C838D4203766CB00DAFEE1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				73AC89C920377EA700038475 /* TwilioVideo.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		738F9D542037604000058972 /* RNTwilioVideoWebRTC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 738F9D5E2037604000058972 /* Build configuration list for PBXNativeTarget "RNTwilioVideoWebRTC" */;
+			buildPhases = (
+				738F9D512037604000058972 /* Sources */,
+				738F9D522037604000058972 /* Frameworks */,
+				738F9D532037604000058972 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNTwilioVideoWebRTC;
+			productName = RNTwilioVideoWebRTC;
+			productReference = 738F9D552037604000058972 /* libRNTwilioVideoWebRTC.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		738F9D4D2037604000058972 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = Employ;
+				TargetAttributes = {
+					738F9D542037604000058972 = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 738F9D502037604000058972 /* Build configuration list for PBXProject "RNTwilioVideoWebRTC" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 738F9D4C2037604000058972;
+			productRefGroup = 738F9D562037604000058972 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				738F9D542037604000058972 /* RNTwilioVideoWebRTC */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		738F9D512037604000058972 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				738F9D6E203760FF00058972 /* RCTTWVideoModule.m in Sources */,
+				738F9D6C203760FF00058972 /* RCTTWRemoteVideoViewManager.m in Sources */,
+				738F9D6B203760FF00058972 /* RCTTWSerializable.m in Sources */,
+				738F9D6D203760FF00058972 /* RCTTWLocalVideoViewManager.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		738F9D5C2037604000058972 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		738F9D5D2037604000058972 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		738F9D5F2037604000058972 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/../../../ios/Frameworks/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/**",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"${SRCROOT}/../../../ios/Pods/TwilioVideo/TwilioVideo/**",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		738F9D602037604000058972 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/../../../ios/Frameworks/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/**",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"${SRCROOT}/../../../ios/Pods/TwilioVideo/TwilioVideo/**",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		738F9D502037604000058972 /* Build configuration list for PBXProject "RNTwilioVideoWebRTC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				738F9D5C2037604000058972 /* Debug */,
+				738F9D5D2037604000058972 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		738F9D5E2037604000058972 /* Build configuration list for PBXNativeTarget "RNTwilioVideoWebRTC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				738F9D5F2037604000058972 /* Debug */,
+				738F9D602037604000058972 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 738F9D4D2037604000058972 /* Project object */;
+}


### PR DESCRIPTION
As amazingly useful as this project has been for me, it has caused serious issues in using with Fastlane and my Podfile while having `use_frameworks` enabled.

So, I created an XCode project for this library, which (in my opinion) simplifies the setup on iOS.

If you choose to merge this, the setup process will be something like this:

1. Add `pod 'TwilioVideo'` to your Podfile
2. Add `RNTwilioVideo.xcodeproj` to the Libraries directory in your project
3. Add `libRNTwilioVideo.a` to the "Linked Frameworks and Libraries"

A further improvement would be to make it so you can just run `react-native link react-native-twilio-video-webrtc` and it performs the 3 steps above. 