### PR TITLE
Make trackId on android match iOS

### DIFF
--- a/src/TwilioVideoParticipantView.android.js
+++ b/src/TwilioVideoParticipantView.android.js
@@ -11,6 +11,12 @@ import React from 'react'
 
 class TwilioRemotePreview extends React.Component {
   static propTypes = {
+    trackIdentifier: PropTypes.shape({
+      /**
+       * The participant's video track you want to render in the view.
+       */
+      videoTrackId: PropTypes.string.isRequired
+    }),
     trackId: PropTypes.string,
     renderToHardwareTextureAndroid: PropTypes.string,
     onLayout: PropTypes.string,
@@ -23,7 +29,8 @@ class TwilioRemotePreview extends React.Component {
   }
 
   render () {
-    return <NativeTwilioRemotePreview {...this.props} />
+    const { trackIdentifier } = this.props;
+    return <NativeTwilioRemotePreview trackId={trackIdentifier && trackIdentifier.videoTrackId} {...this.props}/>
   }
 }
 

--- a/src/TwilioVideoParticipantView.android.js
+++ b/src/TwilioVideoParticipantView.android.js
@@ -29,8 +29,8 @@ class TwilioRemotePreview extends React.Component {
   }
 
   render () {
-    const { trackIdentifier } = this.props;
-    return <NativeTwilioRemotePreview trackId={trackIdentifier && trackIdentifier.videoTrackId} {...this.props}/>
+    const { trackIdentifier } = this.props
+    return <NativeTwilioRemotePreview trackId={trackIdentifier && trackIdentifier.videoTrackId} {...this.props} />
   }
 }
 


### PR DESCRIPTION
For consistency's sake the track ID should be passed as part of the track identifier prop.

I've set this up so that both the previous ad hoc prop and the ios compatible prop will work now.