### PR TITLE
Update docs for flip camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ export default class Example extends Component {
       .then(isEnabled => this.setState({isAudioEnabled: isEnabled}))
   }
 
+  _onFlipButtonPress = () => {
+    this.refs.twilioVideo.flipCamera()
+  }
+
+  _onRoomDidDisconnect = ({roomName, error}) => {
+    console.log("ERROR: ", error)
+
+    this.setState({status: 'disconnected'})
+  }
+
+  _onRoomDidFailToConnect = (error) => {
+    console.log("ERROR: ", error)
+
+    this.setState({status: 'disconnected'})
+  }
+
   _onParticipantAddedVideoTrack = ({participant, track}) => {
     console.log("onParticipantAddedVideoTrack: ", participant, track)
 


### PR DESCRIPTION
The docs had a button press handler that wasn't actually wired up to anything.  This makes it up to date to match the actualy example in the repo.