### PR TITLE
Function to disable OpenSL ES on Android

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -55,6 +55,7 @@ import com.twilio.video.VideoTrackStats;
 import com.twilio.video.VideoView;
 import com.twilio.video.VideoConstraints;
 import com.twilio.video.VideoDimensions;
+import org.webrtc.voiceengine.WebRtcAudioManager;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -512,6 +512,10 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         }
     }
 
+    public void disableOpenSLES() {
+      WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(true);
+    }
+
     // ====== ROOM LISTENER ========================================================================
 
     /*

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -40,6 +40,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     private static final int TOGGLE_VIDEO = 4;
     private static final int TOGGLE_SOUND = 5;
     private static final int GET_STATS = 6;
+    private static final int DISABLE_OPENSL_ES = 7;
 
     @Override
     public String getName() {
@@ -76,6 +77,9 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
             case GET_STATS:
                 view.getStats();
                 break;
+            case DISABLE_OPENSL_ES:
+                view.disableOpenSLES();
+                break;
         }
     }
 
@@ -111,7 +115,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 "switchCamera", SWITCH_CAMERA,
                 "toggleVideo", TOGGLE_VIDEO,
                 "toggleSound", TOGGLE_SOUND,
-                "getStats", GET_STATS
+                "getStats", GET_STATS,
+                "disableOpenSLES", DISABLE_OPENSL_ES
         );
     }
 }

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -85,7 +85,8 @@ const nativeEvents = {
   switchCamera: 3,
   toggleVideo: 4,
   toggleSound: 5,
-  getStats: 6
+  getStats: 6,
+  disableOpenSLES: 7
 }
 
 class CustomTwilioVideoView extends Component {
@@ -111,6 +112,10 @@ class CustomTwilioVideoView extends Component {
 
   getStats () {
     this.runCommand(nativeEvents.getStats, [])
+  }
+
+  disableOpenSLES() {
+    this.runCommand(nativeEvents.disableOpenSLES, [])
   }
 
   runCommand (event, args) {

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -114,7 +114,7 @@ class CustomTwilioVideoView extends Component {
     this.runCommand(nativeEvents.getStats, [])
   }
 
-  disableOpenSLES() {
+  disableOpenSLES () {
     this.runCommand(nativeEvents.disableOpenSLES, [])
   }
 


### PR DESCRIPTION
Per discussion here:
https://github.com/twilio/video-quickstart-android#troubleshooting-audio

and here:
twilio/video-quickstart-android#221

On some devices it may be advisable to disable openSL ES.  This PR exposes that functionality.