### PR TITLE
Update twiliovideo dependency version

### DIFF
--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '>= 1.0.1'
+  s.dependency 'TwilioVideo', '~> 1.1'
 end


### PR DESCRIPTION
The current podspec rule will match 2.x versions.  While there's a branch in progress for TwilioVideo2 support, master doesn't yet support it.  Consequently, this PR changes the dependency rule to use optimistic versioning which should ensure that it stays in 1.x.