### PR TITLE
Support Twilio Video 2.2 on iOS

### DIFF
--- a/ios/RCTTWRemoteVideoViewManager.m
+++ b/ios/RCTTWRemoteVideoViewManager.m
@@ -13,8 +13,8 @@
 
 @interface RCTTWVideoTrackIdentifier : NSObject
 
-@property (strong) NSString *participantIdentity;
-@property (strong) NSString *videoTrackId;
+@property (strong) NSString *participantSid;
+@property (strong) NSString *videoTrackSid;
 
 @end
 
@@ -32,8 +32,8 @@
 
 + (RCTTWVideoTrackIdentifier *)RCTTWVideoTrackIdentifier:(id)json {
   RCTTWVideoTrackIdentifier *trackIdentifier = [[RCTTWVideoTrackIdentifier alloc] init];
-  trackIdentifier.participantIdentity = json[@"participantIdentity"];
-  trackIdentifier.videoTrackId = json[@"videoTrackId"];
+  trackIdentifier.participantSid = json[@"participantSid"];
+  trackIdentifier.videoTrackSid = json[@"videoTrackSid"];
 
   return trackIdentifier;
 }
@@ -60,7 +60,7 @@ RCT_CUSTOM_VIEW_PROPERTY(trackIdentifier, RCTTWVideoTrackIdentifier, TVIVideoVie
     RCTTWVideoModule *videoModule = [self.bridge moduleForName:@"TWVideoModule"];
     RCTTWVideoTrackIdentifier *id = [RCTConvert RCTTWVideoTrackIdentifier:json];
 
-    [videoModule addParticipantView:view.subviews[0] identity:id.participantIdentity trackId:id.videoTrackId];
+    [videoModule addParticipantView:view.subviews[0] sid:id.participantSid trackSid:id.videoTrackSid];
   }
 }
 

--- a/ios/RCTTWSerializable.m
+++ b/ios/RCTTWSerializable.m
@@ -11,15 +11,21 @@
 @implementation TVIParticipant(RCTTWSerializable)
 
 - (id)toJSON {
-  return @{ @"identity": self.identity };
+  return @{
+    @"sid": self.sid,
+    @"identity": self.identity
+  };
 }
 
 @end
 
-@implementation TVITrack(RCTTWSerializable)
+@implementation TVITrackPublication(RCTTWSerializable)
 
 - (id)toJSON {
-  return @{ @"trackId": self.trackId };
+  return @{
+    @"trackSid": self.trackSid,
+    @"trackName": self.trackName
+  };
 }
 
 @end

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -246,7 +246,7 @@ RCT_EXPORT_METHOD(getStats) {
         }
         eventBody[statsReport.peerConnectionId] = @{
           @"remoteAudioTrackStats": audioTrackStats,
-          @"remoteAideoTrackStats": videoTrackStats,
+          @"remoteVideoTrackStats": videoTrackStats,
           @"localAudioTrackStats": localAudioTrackStats,
           @"localVideoTrackStats": localVideoTrackStats
         };

--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 1.1'
+  s.dependency 'TwilioVideo', '~> 2.2.0'
 end

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -77,17 +77,29 @@ export default class extends Component {
      */
     onParticipantRemovedAudioTrack: PropTypes.func,
     /**
-     * Called when a track has been enabled. This can be audio or video tracks
+     * Called when a video track has been enabled.
      *
      * @param {{participant, track}}
      */
-    onParticipantEnabledTrack: PropTypes.func,
+    onParticipantEnabledVideoTrack: PropTypes.func,
     /**
-     * Called when a track has been disabled. This can be audio or video tracks
+     * Called when a video track has been disabled.
      *
      * @param {{participant, track}}
      */
-    onParticipantDisabledTrack: PropTypes.func,
+    onParticipantDisabledVideoTrack: PropTypes.func,
+    /**
+     * Called when an audio track has been enabled.
+     *
+     * @param {{participant, track}}
+     */
+    onParticipantEnabledAudioTrack: PropTypes.func,
+    /**
+     * Called when an audio track has been disabled.
+     *
+     * @param {{participant, track}}
+     */
+    onParticipantDisabledAudioTrack: PropTypes.func,
     /**
      * Called when the camera has started
      *
@@ -232,11 +244,17 @@ export default class extends Component {
       this._eventEmitter.addListener('participantRemovedAudioTrack', (data) => {
         if (this.props.onParticipantRemovedAudioTrack) { this.props.onParticipantRemovedAudioTrack(data) }
       }),
-      this._eventEmitter.addListener('participantEnabledTrack', (data) => {
-        if (this.props.onParticipantEnabledTrack) { this.props.onParticipantEnabledTrack(data) }
+      this._eventEmitter.addListener('participantEnabledVideoTrack', (data) => {
+        if (this.props.onParticipantEnabledVideoTrack) { this.props.onParticipantEnabledVideoTrack(data) }
       }),
-      this._eventEmitter.addListener('participantDisabledTrack', (data) => {
-        if (this.props.onParticipantDisabledTrack) { this.props.onParticipantDisabledTrack(data) }
+      this._eventEmitter.addListener('participantDisabledVideoTrack', (data) => {
+        if (this.props.onParticipantDisabledVideoTrack) { this.props.onParticipantDisabledVideoTrack(data) }
+      }),
+      this._eventEmitter.addListener('participantEnabledAudioTrack', (data) => {
+        if (this.props.onParticipantEnabledAudioTrack) { this.props.onParticipantEnabledAudioTrack(data) }
+      }),
+      this._eventEmitter.addListener('participantDisabledAudioTrack', (data) => {
+        if (this.props.onParticipantDisabledAudioTrack) { this.props.onParticipantDisabledAudioTrack(data) }
       }),
       this._eventEmitter.addListener('cameraDidStart', (data) => {
         if (this.props.onCameraDidStart) { this.props.onCameraDidStart(data) }

--- a/src/TwilioVideoParticipantView.ios.js
+++ b/src/TwilioVideoParticipantView.ios.js
@@ -14,13 +14,13 @@ class TwilioVideoParticipantView extends Component {
   static propTypes = {
     trackIdentifier: PropTypes.shape({
       /**
-       * The participant identifier.
+       * The participant sid.
        */
-      participantIdentity: PropTypes.string.isRequired,
+      participantSid: PropTypes.string.isRequired,
       /**
-       * The participant's video track you want to render in the view.
+       * The participant's video track sid you want to render in the view.
        */
-      videoTrackId: PropTypes.string.isRequired
+      videoTrackSid: PropTypes.string.isRequired
     })
   }
 


### PR DESCRIPTION
This PR updates the library to support version 2.2 of the Twilio Video library.  It does not yet expose any new functionality per-se of v2 of the library; the goal here is feature parity with minimal changes for existing users of the library.

The main user-visible changes are:
* `onParticipant{Enabled/Disabled}Track` are now broken out into separate events for Audio and Video.
* The track identifier prop type now contains two fields: `participantSid` and `videoTrackSid`.  Generally under the hood we try to use sids everywhere as the idenfitier for participants and tracks.  This would necessitate a small change in the example, namely in the `onParticipantAddedVideoTrack` handler set:

```
this.setState({
  participant,
  track,
});
```

and then pass this in as follows:

```
<TwilioVideoParticipantView trackIdentifier={{ participantSid: this.state.participant.sid, videoTrackSid: this.state.track.trackSid }} />
```