### PR TITLE
Update migration docs with events

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ The `trackId` field no longer exists and should be replaced by `trackSid`.  Comm
 participant views now expect `participantSid` and `videoTrackSid` keys in the `trackIdentity` prop (instead of
 `identity` and `trackId`).
 
+* Make sure you're listening to participant events via `onParticipant{Added/Removed}VideoTrack` rather than `onParticipant{Enabled/Disabled}Track`.
+
 ## Contact
 
 - Martín Fernández <fmartin91@gmail.com>


### PR DESCRIPTION
Apparently the old events were causing some confusion as suggested in #130