### PR TITLE
Make build.gradle compatible with newer gradles

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,15 +36,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile "com.twilio:video-android:2.1.0"
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation "com.twilio:video-android:2.1.0"
 
-    compile "com.facebook.react:react-native:+"  // From node_modules
-
-    testCompile 'junit:junit:4.12'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }


### PR DESCRIPTION
This was previously using some deprecated stuff and potentially breaking builds depending on one's android build config.  This should hopefully fix that.

1.) Use `implementation` instead of `compile`.
2.) Get rid of the test depencies for now since we don't have any android tests to speak of.
3.) Get rid of an unneeded library which was causing conflicts with newer appsupport libraries.