### PR TITLE
Update gradle and use rootProject variables

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,15 +43,9 @@ android {
 dependencies {
     def androidSupportVersion = rootProject.hasProperty("androidSupportVersion")  ? rootProject.androidSupportVersion : DEFAULT_ANDROID_SUPPORT_VERSION
     
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:$androidSupportVersion"
-    compile "com.android.support:design:$androidSupportVersion"
-    compile "com.twilio:video-android:2.1.0"
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:appcompat-v7:$androidSupportVersion"
+    implementation "com.twilio:video-android:2.1.0"
 
-    compile "com.facebook.react:react-native:+"  // From node_modules
-
-    testCompile 'junit:junit:4.12'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,17 @@
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION             = 25
+def DEFAULT_BUILD_TOOLS_VERSION             = "25.0.3"
+def DEFAULT_TARGET_SDK_VERSION              = 23
+def DEFAULT_ANDROID_SUPPORT_VERSION         = "25.3.1"
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }
@@ -36,9 +41,11 @@ android {
 }
 
 dependencies {
+    def androidSupportVersion = rootProject.hasProperty("androidSupportVersion")  ? rootProject.androidSupportVersion : DEFAULT_ANDROID_SUPPORT_VERSION
+    
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
+    compile "com.android.support:appcompat-v7:$androidSupportVersion"
+    compile "com.android.support:design:$androidSupportVersion"
     compile "com.twilio:video-android:2.1.0"
 
     compile "com.facebook.react:react-native:+"  // From node_modules


### PR DESCRIPTION
Check rootProject for compileSdkVersion, buildToolsVersion, targetSdkVersion, and androidSupportVersion, with defaults as fallback.

Also including gradle updates from @slycoder 
1. Use implementation instead of compile.
2. Get rid of the test depencies for now since we don't have any android tests to speak of.
3. Get rid of an unneeded library which was causing conflicts with newer appsupport libraries.