### PR TITLE
Add enabled property to onParticipantAddedVideoTrack

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -756,7 +756,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         WritableMap trackMap = new WritableNativeMap();
         trackMap.putString("trackSid", publication.getTrackSid());
         trackMap.putString("trackName", publication.getTrackName());
-
+        trackMap.putBoolean("enabled", publication.isTrackEnabled());
 
         WritableMap event = new WritableNativeMap();
         event.putMap("participant", participantMap);

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ onParticipantAddedVideoTrack: Function
 
 Called when a new video track has been added
 
-@param {{participant, track}}
+@param {{participant, track, enabled}}
 
 #### onParticipantDisabledTrack
 

--- a/ios/RCTTWSerializable.m
+++ b/ios/RCTTWSerializable.m
@@ -24,7 +24,8 @@
 - (id)toJSON {
   return @{
     @"trackSid": self.trackSid,
-    @"trackName": self.trackName
+    @"trackName": self.trackName,
+    @"enabled": @(self.trackEnabled)
   };
 }
 

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -52,7 +52,7 @@ const propTypes = {
   /**
    * Called when a new video track has been added
    *
-   * @param {{participant, track}}
+   * @param {{participant, track, enabled}}
    */
   onParticipantAddedVideoTrack: PropTypes.func,
 

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -55,7 +55,7 @@ export default class extends Component {
     /**
      * Called when a new video track has been added
      *
-     * @param {{participant, track}}
+     * @param {{participant, track, enabled}}
      */
     onParticipantAddedVideoTrack: PropTypes.func,
     /**


### PR DESCRIPTION
Solution to issue: https://github.com/blackuy/react-native-twilio-video-webrtc/issues/154

Added `enabled` property to the `onParticipantAddedVideoTrack` event.

Thanks to that, it can be determined if track is enabled or not and adjust the application accordingly.