### PR TITLE
V2 getStats integration

### DIFF
--- a/ios/RCTTWSerializable.m
+++ b/ios/RCTTWSerializable.m
@@ -19,14 +19,14 @@
 @implementation TVILocalAudioTrack(RCTTWSerializable)
 
 - (id)toJSON {
-  return @{ @"trackId": self.trackId };
+  return @{ @"trackId": self.name };
 }
 @end
 
 @implementation TVILocalVideoTrack(RCTTWSerializable)
 
 - (id)toJSON {
-  return @{ @"trackId": self.trackId };
+  return @{ @"trackId": self.name };
 }
 
 @end

--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -13,11 +13,11 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/blackuy/react-native-twilio-video-web-rtc', tag: s.version }
 
   s.requires_arc   = true
-  s.platform       = :ios, '8.0'
+  s.platform       = :ios, '10.0'
 
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '= 2.0.0-beta1'
+  s.dependency 'TwilioVideo', '= 2.5.3'
 end

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -104,6 +104,11 @@ export default class extends Component {
      * @param {{error}} The error message description
      */
     onCameraDidStopRunning: PropTypes.func,
+    /**
+     * Called when stats are received (after calling getStats)
+     *
+     */
+    onStatsReceived: PropTypes.func,
     ...View.propTypes
   }
 
@@ -152,6 +157,14 @@ export default class extends Component {
   flipCamera () {
     TWVideoModule.flipCamera()
   }
+
+ /**
+   * Get connection stats
+   */
+  getStats () {
+    TWVideoModule.getStats()
+  }
+
 
   /**
    * Connect to given room name using the JWT access token
@@ -234,6 +247,9 @@ export default class extends Component {
       }),
       this._eventEmitter.addListener('cameraDidStopRunning', (data) => {
         if (this.props.onCameraDidStopRunning) { this.props.onCameraDidStopRunning(data) }
+      }),
+      this._eventEmitter.addListener('statsReceived', (data) => {
+        if (this.props.onStatsReceived) { this.props.onStatsReceived(data) }
       })
     ]
   }

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -121,6 +121,7 @@ export default class extends Component {
     this.setLocalVideoEnabled = this.setLocalVideoEnabled.bind(this)
     this.setLocalAudioEnabled = this.setLocalAudioEnabled.bind(this)
     this.flipCamera = this.flipCamera.bind(this)
+    this.getStats = this.getStats.bind(this)
     this.connect = this.connect.bind(this)
     this.disconnect = this.disconnect.bind(this)
   }

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -109,7 +109,7 @@ export default class extends Component {
      *
      */
     onStatsReceived: PropTypes.func,
-    ...View.propTypes
+    ...View.propTypes 
   }
 
   constructor (props) {


### PR DESCRIPTION
Added getStats capability on TwilioVideo library version 2 !

The aim is to be able to get bandwidth data (download, upload ...) in real time.

Also : 
- updated TwilioVideo dependency to 2.5.3
- ios platform to 10 (for new dependency)
- in RCTTWSerializable fixed a bug where trackId is not used anymore

This has been tested in production and used internally.