### PR TITLE
adds scaleType prop for rendering participant and local views

### DIFF
--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
@@ -24,6 +24,15 @@ public class TwilioRemotePreviewManager extends SimpleViewManager<TwilioRemotePr
         return REACT_CLASS;
     }
 
+    @ReactProp(name = "scaleType")
+    public void setScaleType(TwilioVideoPreview view, @Nullable String scaleType){
+      if(scaleType.equals('fit'))
+      {
+        view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT);
+      } else {
+        view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);
+      }
+    }
 
     @ReactProp(name = "trackSid")
     public void setTrackId(TwilioRemotePreview view, @Nullable String trackSid) {

--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreviewManager.java
@@ -25,9 +25,8 @@ public class TwilioRemotePreviewManager extends SimpleViewManager<TwilioRemotePr
     }
 
     @ReactProp(name = "scaleType")
-    public void setScaleType(TwilioVideoPreview view, @Nullable String scaleType){
-      if(scaleType.equals('fit'))
-      {
+    public void setScaleType(TwilioVideoPreview view, @Nullable String scaleType) {
+      if(scaleType.equals('fit')) {
         view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT);
       } else {
         view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
@@ -17,6 +17,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 
 import java.util.Map;
 
+import org.webrtc.RendererCommon;
 
 public class TwilioVideoPreviewManager extends SimpleViewManager<TwilioVideoPreview> {
 
@@ -25,6 +26,16 @@ public class TwilioVideoPreviewManager extends SimpleViewManager<TwilioVideoPrev
     @Override
     public String getName() {
         return REACT_CLASS;
+    }
+
+    @ReactProp(name = "scaleType")
+    public void setScaleType(TwilioVideoPreview view, @Nullable String scaleType){
+      if(scaleType.equals('fit'))
+      {
+        view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT);
+      } else {
+        view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);
+      }
     }
 
     @Override

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
@@ -29,9 +29,8 @@ public class TwilioVideoPreviewManager extends SimpleViewManager<TwilioVideoPrev
     }
 
     @ReactProp(name = "scaleType")
-    public void setScaleType(TwilioVideoPreview view, @Nullable String scaleType){
-      if(scaleType.equals('fit'))
-      {
+    public void setScaleType(TwilioVideoPreview view, @Nullable String scaleType) {
+      if(scaleType.equals('fit')) {
         view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT);
       } else {
         view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);

--- a/ios/RCTTWLocalVideoViewManager.m
+++ b/ios/RCTTWLocalVideoViewManager.m
@@ -17,10 +17,13 @@
 
 RCT_EXPORT_MODULE()
 
+RCT_CUSTOM_VIEW_PROPERTY(scalesType, NSInteger, TVIVideoView){
+  view.subviews[0].contentMode = [RCTConvert NSInteger:json];
+}
+
 - (UIView *)view {
   UIView *container = [[UIView alloc] init];
   TVIVideoView *inner = [[TVIVideoView alloc] init];
-  inner.contentMode = UIViewContentModeScaleAspectFill;
   [container addSubview:inner];
   return container;
 }

--- a/ios/RCTTWLocalVideoViewManager.m
+++ b/ios/RCTTWLocalVideoViewManager.m
@@ -17,7 +17,7 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_CUSTOM_VIEW_PROPERTY(scalesType, NSInteger, TVIVideoView){
+RCT_CUSTOM_VIEW_PROPERTY(scalesType, NSInteger, TVIVideoView) {
   view.subviews[0].contentMode = [RCTConvert NSInteger:json];
 }
 

--- a/ios/RCTTWRemoteVideoViewManager.m
+++ b/ios/RCTTWRemoteVideoViewManager.m
@@ -47,7 +47,7 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_CUSTOM_VIEW_PROPERTY(scalesType, NSInteger, TVIVideoView){
+RCT_CUSTOM_VIEW_PROPERTY(scalesType, NSInteger, TVIVideoView) {
   view.subviews[0].contentMode = [RCTConvert NSInteger:json];
 }
 

--- a/ios/RCTTWRemoteVideoViewManager.m
+++ b/ios/RCTTWRemoteVideoViewManager.m
@@ -47,10 +47,13 @@
 
 RCT_EXPORT_MODULE()
 
+RCT_CUSTOM_VIEW_PROPERTY(scalesType, NSInteger, TVIVideoView){
+  view.subviews[0].contentMode = [RCTConvert NSInteger:json];
+}
+
 - (UIView *)view {
   UIView *container = [[UIView alloc] init];
   TVIVideoView *inner = [[TVIVideoView alloc] init];
-  inner.contentMode = UIViewContentModeScaleAspectFill;
   [container addSubview:inner];
   return container;
 }

--- a/src/TwilioVideoLocalView.ios.js
+++ b/src/TwilioVideoLocalView.ios.js
@@ -19,7 +19,7 @@ class TwilioVideoLocalView extends Component {
   }
 
   render () {
-    scalesType = this.props.scaleType === 'fit' ? 1 : 2
+    let scalesType = this.props.scaleType === 'fit' ? 1 : 2
     return <RCTTWLocalVideoView scalesType={scalesType} {...this.props}>{this.props.children}</RCTTWLocalVideoView>
   }
 }

--- a/src/TwilioVideoLocalView.ios.js
+++ b/src/TwilioVideoLocalView.ios.js
@@ -20,7 +20,7 @@ class TwilioVideoLocalView extends Component {
 
   render () {
     scalesType = this.props.scaleType === 'fit' ? 1 : 2
-    return <RCTTWLocalVideoView {...this.props}>{this.props.children}</RCTTWLocalVideoView>
+    return <RCTTWLocalVideoView scalesType={scalesType} {...this.props}>{this.props.children}</RCTTWLocalVideoView>
   }
 }
 

--- a/src/TwilioVideoLocalView.ios.js
+++ b/src/TwilioVideoLocalView.ios.js
@@ -19,6 +19,7 @@ class TwilioVideoLocalView extends Component {
   }
 
   render () {
+    scalesType = this.props.scaleType === 'fit' ? 1 : 2
     return <RCTTWLocalVideoView {...this.props}>{this.props.children}</RCTTWLocalVideoView>
   }
 }

--- a/src/TwilioVideoParticipantView.ios.js
+++ b/src/TwilioVideoParticipantView.ios.js
@@ -25,7 +25,8 @@ class TwilioVideoParticipantView extends Component {
   }
 
   render () {
-    return <RCTTWRemoteVideoView {...this.props}>{this.props.children}</RCTTWRemoteVideoView>
+    scalesType = this.props.scaleType === 'fit' ? 1 : 2
+    return <RCTTWRemoteVideoView scalesType={scalesType} {...this.props}>{this.props.children}</RCTTWRemoteVideoView>
   }
 }
 

--- a/src/TwilioVideoParticipantView.ios.js
+++ b/src/TwilioVideoParticipantView.ios.js
@@ -25,7 +25,7 @@ class TwilioVideoParticipantView extends Component {
   }
 
   render () {
-    scalesType = this.props.scaleType === 'fit' ? 1 : 2
+    let scalesType = this.props.scaleType === 'fit' ? 1 : 2
     return <RCTTWRemoteVideoView scalesType={scalesType} {...this.props}>{this.props.children}</RCTTWRemoteVideoView>
   }
 }


### PR DESCRIPTION
Creates scaleType prop for use in either TwilioVideoParticipantView or TwilioVideoLocalView. 

Use 'fit" to scale video render to original proportions. Default remains "fill", which crops the video to fill the entire screen.  