### PR TITLE
Move some dependencies into dev dependencies

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -602,7 +602,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             @Override
             public void onDisconnected(Room room, TwilioException e) {
                 WritableMap event = new WritableNativeMap();
-                event.putString("participant", localParticipant.getIdentity());
+                if (localParticipant != null) {
+                  event.putString("participant", localParticipant.getIdentity());
+                }
                 pushEvent(CustomTwilioVideoView.this, ON_DISCONNECTED, event);
 
                 localParticipant = null;

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -378,7 +378,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 audioManager.abandonAudioFocus(this);
             } else {
-                audioManager.abandonAudioFocusRequest(audioFocusRequest);
+                if (audioFocusRequest != null) {
+                    audioManager.abandonAudioFocusRequest(audioFocusRequest);
+                }
             }
 
             audioManager.setSpeakerphoneOn(false);

--- a/package.json
+++ b/package.json
@@ -24,17 +24,17 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "^7.2.3",
-    "gulp-react-docs": "^0.1.2",
-    "react-docgen": "^2.15.0",
-    "standard": "^10.0.3"
-  },
-  "dependencies": {
     "del": "^3.0.0",
     "doctoc": "^1.3.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-load-plugins": "^1.5.0",
+    "gulp-react-docs": "^0.1.2",
     "gulp-tap": "^1.0.1",
+    "react-docgen": "^2.15.0",
+    "standard": "^10.0.3"
+  },
+  "dependencies": {
     "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
There are certain race conditions where localParticipant is not set and yet we get an onDisconnect.  Don't bother logging the participant to the event in these cases.