### PR TITLE
Handle case where audioFocusRequest is NULL

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -378,7 +378,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 audioManager.abandonAudioFocus(this);
             } else {
-                audioManager.abandonAudioFocusRequest(audioFocusRequest);
+                if (audioFocusRequest != null) {
+                    audioManager.abandonAudioFocusRequest(audioFocusRequest);
+                }
             }
 
             audioManager.setSpeakerphoneOn(false);

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -613,7 +613,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             @Override
             public void onDisconnected(Room room, TwilioException e) {
                 WritableMap event = new WritableNativeMap();
-                event.putString("participant", localParticipant.getIdentity());
+                if (localParticipant != null) {
+                  event.putString("participant", localParticipant.getIdentity());
+                }
                 pushEvent(CustomTwilioVideoView.this, ON_DISCONNECTED, event);
 
                 localParticipant = null;


### PR DESCRIPTION
In our Sentry logging, we've occasionally, seen an error thrown that is `Illegal audioFocusRequest is null`. We haven't been able to reproduce, but believe that this is a race condition in our code that allows `disconnect` to be called before `connect` has been completed. We've been able to fix but adding guardrails in for this case, but figure that this change might also be helpful to prevent others from having same issue.