### PR TITLE
[android] Release resource when unmounting

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -311,6 +311,13 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         Log.e(TAG, "onAudioFocusChange: focuschange: " + focusChange);
     }
 
+    public void releaseResource() {
+        themedReactContext.removeLifecycleEventListener(this);
+        room = null;
+        localVideoTrack = null;
+        thumbnailVideoView = null;
+        cameraCapturer = null;
+    }
 
     // ====== CONNECTING ===========================================================================
 

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -175,6 +175,8 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         audioManager = (AudioManager) themedReactContext.getSystemService(Context.AUDIO_SERVICE);
         myNoisyAudioStreamReceiver = new BecomingNoisyReceiver();
         intentFilter = new IntentFilter(Intent.ACTION_HEADSET_PLUG);
+
+        createLocalMedia();
     }
 
     // ===== SETUP =================================================================================
@@ -222,7 +224,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             }
             setThumbnailMirror();
         }
-        connectToRoom();
     }
 
     // ===== LIFECYCLE EVENTS ======================================================================
@@ -323,8 +324,8 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             createLocalMedia();
         } else {
             localAudioTrack = LocalAudioTrack.create(getContext(), true);
-            connectToRoom();
         }
+        connectToRoom();
     }
 
     public void connectToRoom() {

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -48,6 +48,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     private static final int GET_STATS = 6;
     private static final int DISABLE_OPENSL_ES = 7;
     private static final int TOGGLE_SOUND_SETUP = 8;
+    private static final int RELEASE_RESOURCE = 9;
 
     @Override
     public String getName() {
@@ -90,6 +91,9 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
             case TOGGLE_SOUND_SETUP:
                 Boolean speaker = args.getBoolean(0);
                 view.toggleSoundSetup(speaker);
+                break;
+            case RELEASE_RESOURCE:
+                view.releaseResource();
                 break;
         }
     }

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -124,10 +124,16 @@ const nativeEvents = {
   toggleSound: 5,
   getStats: 6,
   disableOpenSLES: 7,
-  toggleSoundSetup: 8
+  toggleSoundSetup: 8,
+  releaseResource: 9,
 }
 
 class CustomTwilioVideoView extends Component {
+
+  componentWillUnmount() {
+    this.runCommand(nativeEvents.releaseResource, []);
+  }
+
   connect ({roomName, accessToken}) {
     this.runCommand(nativeEvents.connectToRoom, [roomName, accessToken])
   }

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -125,13 +125,12 @@ const nativeEvents = {
   getStats: 6,
   disableOpenSLES: 7,
   toggleSoundSetup: 8,
-  releaseResource: 9,
+  releaseResource: 9
 }
 
 class CustomTwilioVideoView extends Component {
-
-  componentWillUnmount() {
-    this.runCommand(nativeEvents.releaseResource, []);
+  componentWillUnmount () {
+    this.runCommand(nativeEvents.releaseResource, [])
   }
 
   connect ({roomName, accessToken}) {


### PR DESCRIPTION
Currently, each time new instance of CustomTwilioVideoView created, it register life cycle event listener. So this PR will remove listener and release some static variables when component unmount.

Fix bug #95 

Please help to review!