### PR TITLE
Updating TwilioVideo to 2.10.1

### DIFF
--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -19,5 +19,8 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 2.7.0'
+  s.dependency 'TwilioVideo', '~> 2.10.1'
+  # 2.10.2 should fix iOS 13 simulator crashes
+  # should upgrade once it becomes available
+  # s.dependency 'TwilioVideo', '~> 2.10.2'
 end


### PR DESCRIPTION
This is to correct a fatal iOS bug.
Note that this version will still crash on an iOS simulator running iOS 13, but it should work fine on actual devices.