### PR TITLE
Run onLayout when video dimensions change (Android)

### DIFF
--- a/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
+++ b/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
@@ -8,6 +8,8 @@ package com.twiliorn.library;
 
 import android.content.Context;
 import android.graphics.Point;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.ViewGroup;
 
 import com.twilio.video.VideoRenderer;
@@ -44,6 +46,13 @@ public class RNVideoViewGroup extends ViewGroup {
                             videoWidth = vw;
                             RNVideoViewGroup.this.forceLayout();
                         }
+                        new Handler(Looper.getMainLooper()).post(new Runnable(){
+                            @Override
+                            public void run() {
+                                RNVideoViewGroup me = RNVideoViewGroup.this;
+                                me.onLayout(true, me.getLeft(), me.getTop(), me.getRight(), me.getBottom());
+                            }
+                        });
                     }
                 }
         );


### PR DESCRIPTION
For issue #241 
Currently on Android the aspect ratio of the video will be off if they are not the Twilio default, and nothing changes the container view.
This addition will run onLayout when the dimensions change so the video will always have the correct aspect ratio.