### PR TITLE
feat: Jest mocks

### DIFF
--- a/jest/react-native-twilio-video-webrtc-mock.js
+++ b/jest/react-native-twilio-video-webrtc-mock.js
@@ -1,0 +1,42 @@
+
+class TwilioVideoMock extends Component {
+  connect = () => {}
+
+  disconnect = () => {}
+
+  setLocalAudioEnabled = () => {}
+
+  setLocalVideoEnabled = () => {}
+
+  toggleSoundSetup = () => {}
+
+  flipCamera = () => {}
+
+  setRemoteAudioPlayback = () => {}
+
+  getStats = () => {}
+
+  render() {
+      return (<div />);
+  }
+}
+
+class TwilioVideoLocalViewMock extends Component {
+  render() {
+      return (<div />);
+  }
+}
+
+class TwilioVideoParticipantViewMock extends Component {
+  render() {
+      return (<div />);
+  }
+}
+
+const asMock = {
+  TwilioVideo: TwilioVideoMock,
+  TwilioVideoLocalView: TwilioVideoLocalViewMock,
+  TwilioVideoParticipantView: TwilioVideoParticipantViewMock,
+};
+
+export default asMock;


### PR DESCRIPTION
Many React Native applications nowadays use either Jest or Enzyme to performed automated testing. However, one challenge of these test frameworks is the difficulty testing native code. The approach commonly used by the @react-native-community libraries is to provide a mock file with the  component stubbed out and in some cases some basic functionality ([example](https://github.com/react-native-community/async-storage/blob/LEGACY/jest/async-storage-mock.js))

I've been using this mock with basic stubs for testing of our app that uses react-native-twilio-video and figured it might be good to add to the repo so that other users can get the same functionality. 