### PR TITLE
dataTrack support added.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,10 @@ android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
     buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -283,6 +283,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
 
     // ===== LIFECYCLE EVENTS ======================================================================
 
+
     @Override
     public void onHostResume() {
         /*
@@ -358,6 +359,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             localAudioTrack.release();
             localAudioTrack = null;
         }
+
+        // Quit the data track message thread
+        dataTrackMessageThread.quit();
 
 
     }
@@ -865,7 +869,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             public void onDataTrackSubscribed(RemoteParticipant remoteParticipant, RemoteDataTrackPublication remoteDataTrackPublication, RemoteDataTrack remoteDataTrack) {
                  WritableMap event = buildParticipantDataEvent(remoteParticipant);
                  pushEvent(CustomTwilioVideoView.this, ON_PARTICIPANT_ADDED_DATA_TRACK, event);
-                 //Log.d(TAG, "ON_PARTICIPANT_ADDED_DATA_TRACK: ");
                  dataTrackMessageThreadHandler.post(() -> addRemoteDataTrack(remoteParticipant, remoteDataTrack));
             }
 
@@ -873,7 +876,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             public void onDataTrackUnsubscribed(RemoteParticipant remoteParticipant, RemoteDataTrackPublication publication, RemoteDataTrack remoteDataTrack) {
                  WritableMap event = buildParticipantDataEvent(remoteParticipant);
                  pushEvent(CustomTwilioVideoView.this, ON_PARTICIPANT_REMOVED_DATA_TRACK, event);
-                 //Log.d(TAG, "ON_PARTICIPANT_REMOVED_DATA_TRACK: ");
             }
 
             @Override
@@ -1033,7 +1035,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
 
             @Override
             public void onMessage(RemoteDataTrack remoteDataTrack, String message) {
-                //Log.d(TAG, "ON_DATATRACK_MESSAGE_RECEIVED: " + message);
                 WritableMap event = buildDataTrackEvent(message);
                 pushEvent(CustomTwilioVideoView.this, ON_DATATRACK_MESSAGE_RECEIVED, event);
             }

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -26,6 +26,9 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DISCONNECTED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_CONNECTED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_DISCONNECTED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_VIDEO_CHANGED;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_REMOVED_DATA_TRACK;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_DATA_TRACK;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DATATRACK_MESSAGE_RECEIVED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_VIDEO_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_REMOVED_VIDEO_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_AUDIO_TRACK;
@@ -51,6 +54,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     private static final int TOGGLE_REMOTE_SOUND = 9;
     private static final int RELEASE_RESOURCE = 10;
     private static final int TOGGLE_BLUETOOTH_HEADSET = 11;
+    private static final int SEND_STRING = 12;
 
     @Override
     public String getName() {
@@ -108,6 +112,9 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 Boolean headsetEnabled = args.getBoolean(0);
                 view.toggleBluetoothHeadset(headsetEnabled);
                 break;
+            case SEND_STRING:
+                view.sendString(args.getString(0));
+                break;
         }
     }
 
@@ -126,11 +133,18 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
 
         map.putAll(MapBuilder.of(
                 ON_PARTICIPANT_DISCONNECTED, MapBuilder.of("registrationName", ON_PARTICIPANT_DISCONNECTED),
+                ON_DATATRACK_MESSAGE_RECEIVED, MapBuilder.of("registrationName", ON_DATATRACK_MESSAGE_RECEIVED),
+                ON_PARTICIPANT_ADDED_DATA_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ADDED_DATA_TRACK),
                 ON_PARTICIPANT_ADDED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ADDED_VIDEO_TRACK),
                 ON_PARTICIPANT_REMOVED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_VIDEO_TRACK),
                 ON_PARTICIPANT_ADDED_AUDIO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ADDED_AUDIO_TRACK),
                 ON_PARTICIPANT_REMOVED_AUDIO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_AUDIO_TRACK)
         ));
+
+        map.putAll(MapBuilder.of(
+                ON_PARTICIPANT_REMOVED_DATA_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_DATA_TRACK)
+        ));
+
         map.putAll(MapBuilder.of(
                 ON_PARTICIPANT_ENABLED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ENABLED_VIDEO_TRACK),
                 ON_PARTICIPANT_DISABLED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_DISABLED_VIDEO_TRACK),
@@ -155,6 +169,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 .put("disableOpenSLES", DISABLE_OPENSL_ES)
                 .put("toggleRemoteSound", TOGGLE_REMOTE_SOUND)
                 .put("toggleBluetoothHeadset", TOGGLE_BLUETOOTH_HEADSET)
+                .put("sendString", SEND_STRING)
                 .build();
     }
 }

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -332,8 +332,6 @@ RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName)
 }
 
 RCT_EXPORT_METHOD(sendString:(nonnull NSString *)message) {
-    NSLog(@"Send String!");
-    NSLog(@"%@", message);
     [self.localDataTrack sendString:message];
     //NSData *data = [message dataUsingEncoding:NSUTF8StringEncoding];
     //[self.localDataTrack sendString:message];
@@ -383,7 +381,6 @@ RCT_EXPORT_METHOD(disconnect) {
     [participants addObject:[p toJSON]];
   }
   TVILocalParticipant *localParticipant = room.localParticipant;
-  //localParticipant.publishDataTrack(localDataTrack)
   [participants addObject:[localParticipant toJSON]];
     [self sendEventCheckingListenerWithName:roomDidConnect body:@{ @"roomName" : room.name , @"roomSid": room.sid, @"participants" : participants }];
 
@@ -473,6 +470,8 @@ RCT_EXPORT_METHOD(disconnect) {
 }
 
 - (void)remoteDataTrack:(nonnull TVIRemoteDataTrack *)remoteDataTrack didReceiveData:(nonnull NSData *)message {
+    // TODO: Handle didReceiveData
+    NSLog(@"DataTrack didReceiveData");
 }
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/blackuy/react-native-twilio-video-webrtc.git"
   },
   "homepage": "https://github.com/blackuy/react-native-twilio-video-webrtc",
-  "version": "1.0.2-0",
+  "version": "1.0.2-1",
   "description": "Twilio Video WebRTC for React Native.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/blackuy/react-native-twilio-video-webrtc.git"
   },
   "homepage": "https://github.com/blackuy/react-native-twilio-video-webrtc",
-  "version": "1.0.2",
+  "version": "1.0.2-0",
   "description": "Twilio Video WebRTC for React Native.",
   "main": "index.js",
   "scripts": {

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -50,6 +50,28 @@ const propTypes = {
   onRoomDidDisconnect: PropTypes.func,
 
   /**
+   * Called when a new data track has been added
+   *
+   * @param {{participant, track}}
+   */
+  onParticipantAddedDataTrack: PropTypes.func,
+
+    /**
+   * Called when a data track has been removed
+   *
+   * @param {{participant, track}}
+   */
+  onParticipantRemovedDataTrack: PropTypes.func,
+
+
+  /**
+   * Called when an dataTrack receives a message
+   *
+   * @param {{message}}
+   */
+  onDataTrackMessageReceived: PropTypes.func,
+
+  /**
    * Called when a new video track has been added
    *
    * @param {{participant, track, enabled}}
@@ -127,7 +149,8 @@ const nativeEvents = {
   toggleSoundSetup: 8,
   toggleRemoteSound: 9,
   releaseResource: 10,
-  toggleBluetoothHeadset: 11
+  toggleBluetoothHeadset: 11,
+  sendString: 12
 }
 
 class CustomTwilioVideoView extends Component {
@@ -144,6 +167,12 @@ class CustomTwilioVideoView extends Component {
       enableAudio,
       enableVideo,
       enableRemoteAudio
+    ])
+  }
+
+  sendString( message ){
+    this.runCommand(nativeEvents.sendString, [
+      message
     ])
   }
 
@@ -213,6 +242,9 @@ class CustomTwilioVideoView extends Component {
       'onRoomDidConnect',
       'onRoomDidFailToConnect',
       'onRoomDidDisconnect',
+      'onParticipantAddedDataTrack',
+      'onParticipantRemovedDataTrack',
+      'onDataTrackMessageReceived',
       'onParticipantAddedVideoTrack',
       'onParticipantRemovedVideoTrack',
       'onParticipantAddedAudioTrack',

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -61,6 +61,18 @@ export default class extends Component {
      */
     onParticipantRemovedVideoTrack: PropTypes.func,
     /**
+     * Called when a new data track has been added
+     *
+     * @param {{participant, track}}
+     */
+    onParticipantAddedDataTrack: PropTypes.func,
+    /**
+     * Called when a data track has been removed
+     *
+     * @param {{participant, track}}
+     */
+    onParticipantRemovedDataTrack: PropTypes.func,
+    /**
      * Called when a new audio track has been added
      *
      * @param {{participant, track}}
@@ -97,6 +109,12 @@ export default class extends Component {
      */
     onParticipantDisabledAudioTrack: PropTypes.func,
     /**
+     * Called when an dataTrack receives a message
+     *
+     * @param {{message}}
+     */
+    onDataTrackMessageReceived: PropTypes.func,
+    /**
      * Called when the camera has started
      *
      */
@@ -131,6 +149,7 @@ export default class extends Component {
     this.flipCamera = this.flipCamera.bind(this)
     this.connect = this.connect.bind(this)
     this.disconnect = this.disconnect.bind(this)
+    this.sendString = this.sendString.bind(this)
     this.setRemoteAudioPlayback = this.setRemoteAudioPlayback.bind(this)
   }
 
@@ -212,6 +231,14 @@ export default class extends Component {
     TWVideoModule.disconnect()
   }
 
+    /**
+   * SendString to datatrack
+   * @param  {String} message    The message string to send
+   */
+  sendString ( message ) {
+    TWVideoModule.sendString(message)
+  }
+
   _startLocalVideo () {
     const screenShare = this.props.screenShare || false
     TWVideoModule.startLocalVideo(screenShare)
@@ -268,6 +295,16 @@ export default class extends Component {
           this.props.onParticipantAddedVideoTrack(data)
         }
       }),
+      this._eventEmitter.addListener('participantAddedDataTrack', data => {
+        if (this.props.onParticipantAddedDataTrack) {
+          this.props.onParticipantAddedDataTrack(data)
+        }
+      }),
+      this._eventEmitter.addListener('participantRemovedDataTrack', data => {
+        if (this.props.onParticipantRemovedDataTrack) {
+          this.props.onParticipantRemovedDataTrack(data)
+        }
+      }),
       this._eventEmitter.addListener('participantRemovedVideoTrack', data => {
         if (this.props.onParticipantRemovedVideoTrack) {
           this.props.onParticipantRemovedVideoTrack(data)
@@ -301,6 +338,11 @@ export default class extends Component {
       this._eventEmitter.addListener('participantDisabledAudioTrack', data => {
         if (this.props.onParticipantDisabledAudioTrack) {
           this.props.onParticipantDisabledAudioTrack(data)
+        }
+      }),
+      this._eventEmitter.addListener('dataTrackMessageReceived', data => {
+        if (this.props.onDataTrackMessageReceived) {
+          this.props.onDataTrackMessageReceived(data)
         }
       }),
       this._eventEmitter.addListener('cameraDidStart', data => {


### PR DESCRIPTION
dataTracks for using Twilios 'UDP like' networking to send packets between clients.

onDataTrackMessageReceived, 
sendString, 
onParticipantAddedDataTrack, 
onParticipantRemovedDataTrack

iOS and android tested in a very complex activity based video call app.
No crashes, No errors on logcat, react native, gradle, xCode.

The only things I decided not to fully complete, and I don't really wish to:
- onParticipantAddedDataTrack/ onParticipantRemovedDataTrack the events don't have the most useful information, I didn't need that information.
- the dataTrack isn't part of the 'stats' report.
- sendString is only supported I didn't add sendData. As in react native it's very easy to stringify/parse a JSON object. Though maybe sendData is better performance I don't know.
