### PR TITLE
check myNoisyAudioStreamReceiver before unregistering

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -458,7 +458,10 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             audioManager.setSpeakerphoneOn(false);
             audioManager.setMode(previousAudioMode);
             try {
-                getContext().unregisterReceiver(myNoisyAudioStreamReceiver);
+                if (myNoisyAudioStreamReceiver != null) {
+                    getContext().unregisterReceiver(myNoisyAudioStreamReceiver);
+                }
+                myNoisyAudioStreamReceiver = null;
             } catch (Exception e) {
                 // already registered
                 e.printStackTrace();


### PR DESCRIPTION
Prevent error trying ot unregister receiver when its already been unregistered. Happens frequently when app is in (or going to) background. IE

`2020-05-04 15:39:39.639 24200-24200/? W/System.err: java.lang.IllegalArgumentException: Receiver not registered: com.twiliorn.library.CustomTwilioVideoView$BecomingNoisyReceiver@bdf297f
2020-05-04 15:39:39.639 24200-24200/? W/System.err:     at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:1271)
2020-05-04 15:39:39.639 24200-24200/? W/System.err:     at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1504)
2020-05-04 15:39:39.639 24200-24200/? W/System.err:     at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:659)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:659)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at com.twiliorn.library.CustomTwilioVideoView.setAudioFocus(CustomTwilioVideoView.java:462)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at com.twiliorn.library.CustomTwilioVideoView.access$1400(CustomTwilioVideoView.java:98)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at com.twiliorn.library.CustomTwilioVideoView$3.onDisconnected(CustomTwilioVideoView.java:762)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at com.twilio.video.Video$2.onDisconnected(Video.java:185)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at com.twilio.video.Room$1.lambda$onDisconnected$4$Room$1(Room.java:150)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at com.twilio.video.-$$Lambda$Room$1$ZNVpZ-qxz87vdKMI7r9ywt-W_hA.run(Unknown Source:6)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at android.os.Handler.handleCallback(Handler.java:873)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at android.os.Handler.dispatchMessage(Handler.java:99)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at android.os.Looper.loop(Looper.java:193)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at android.app.ActivityThread.main(ActivityThread.java:6718)
2020-05-04 15:39:39.640 24200-24200/? W/System.err:     at java.lang.reflect.Method.invoke(Native Method)
2020-05-04 15:39:39.641 24200-24200/? W/System.err:     at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
2020-05-04 15:39:39.641 24200-24200/? W/System.err:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)`