### PR TITLE
Fix error message on android connect failure

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -265,7 +265,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         }
         if (cameraCapturer == null){
             WritableMap event = new WritableNativeMap();
-            event.putString("reason", "No camera is supported on this device");
+            event.putString("error", "No camera is supported on this device");
             pushEvent(CustomTwilioVideoView.this, ON_CONNECT_FAILURE, event);
             return;
         }
@@ -728,7 +728,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
                 WritableMap event = new WritableNativeMap();
                 event.putString("roomName", room.getName());
                 event.putString("roomSid", room.getSid());
-                event.putString("reason", e.getExplanation());
+                event.putString("error", e.getMessage());
                 pushEvent(CustomTwilioVideoView.this, ON_CONNECT_FAILURE, event);
             }
 


### PR DESCRIPTION
a.) Make the field `error` to be consistent with iOS.
b.) Get the proper message field from the exception.