### PR TITLE
Actually unpublish video instead of pausing

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -379,7 +379,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         this.enableRemoteAudio = enableAudio;
 
         // Share your microphone
-            localAudioTrack = LocalAudioTrack.create(getContext(), enableAudio);
+        localAudioTrack = LocalAudioTrack.create(getContext(), enableAudio);
 
         if (cameraCapturer == null) {
             boolean createVideoStatus = createLocalVideo(enableVideo);
@@ -546,7 +546,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         }
         if (room == null) {
             // No room to publish/unpublish from
-            return;
         } else {
             if (enabled) {
                  if (localVideoTrack != null) {

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -350,6 +350,11 @@ RCT_EXPORT_METHOD(getStats) {
 }
 
 RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName) {
+  if (self.localVideoTrack == nil) {
+    // We disabled video in a previous call, attempt to re-enable
+    [self startLocalVideo];
+  }
+
   TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithToken:accessToken block:^(TVIConnectOptionsBuilder * _Nonnull builder) {
     if (self.localVideoTrack) {
       builder.videoTracks = @[self.localVideoTrack];

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -188,7 +188,33 @@ RCT_REMAP_METHOD(setLocalAudioEnabled, enabled:(BOOL)enabled setLocalAudioEnable
 
 RCT_REMAP_METHOD(setLocalVideoEnabled, enabled:(BOOL)enabled setLocalVideoEnabledWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-  [self.localVideoTrack setEnabled:enabled];
+  if (self.localVideoTrack != nil) {
+    [self.localVideoTrack setEnabled:enabled];
+  }
+  if (self.room == nil) {
+    // No room to add/remove tracks from, so ignore.
+    return;
+  }
+
+  if (enabled) {
+    if (self.localVideoTrack != nil) {
+      // Already enabled
+      return;
+    }
+    [self startLocalVideo];
+    if (self.localVideoTrack != nil) {
+      [[self.room localParticipant] publishVideoTrack:self.localVideoTrack];
+    }
+  } else {
+    if (self.localVideoTrack == nil) {
+      // Already disabled;
+      return;
+    }
+    [[self.room localParticipant] unpublishVideoTrack:self.localVideoTrack];
+    [self.camera stopCapture];
+    self.localVideoTrack = nil;
+    self.camera = nil;
+  }
 
   resolve(@(enabled));
 }

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -191,29 +191,29 @@ RCT_REMAP_METHOD(setLocalVideoEnabled, enabled:(BOOL)enabled setLocalVideoEnable
   if (self.localVideoTrack != nil) {
     [self.localVideoTrack setEnabled:enabled];
   }
+
   if (self.room == nil) {
     // No room to add/remove tracks from, so ignore.
-    return;
-  }
-
-  if (enabled) {
-    if (self.localVideoTrack != nil) {
-      // Already enabled
-      return;
-    }
-    [self startLocalVideo];
-    if (self.localVideoTrack != nil) {
-      [[self.room localParticipant] publishVideoTrack:self.localVideoTrack];
-    }
   } else {
-    if (self.localVideoTrack == nil) {
-      // Already disabled;
-      return;
+    if (enabled) {
+      if (self.localVideoTrack != nil) {
+        // Already enabled
+      } else {
+        [self startLocalVideo];
+        if (self.localVideoTrack != nil) {
+          [[self.room localParticipant] publishVideoTrack:self.localVideoTrack];
+        }
+      }
+    } else {
+      if (self.localVideoTrack == nil) {
+        // Already disabled;
+      } else {
+        [[self.room localParticipant] unpublishVideoTrack:self.localVideoTrack];
+        [self.camera stopCapture];
+        self.localVideoTrack = nil;
+        self.camera = nil;
+      }
     }
-    [[self.room localParticipant] unpublishVideoTrack:self.localVideoTrack];
-    [self.camera stopCapture];
-    self.localVideoTrack = nil;
-    self.camera = nil;
   }
 
   resolve(@(enabled));


### PR DESCRIPTION
Currently we do not actually unpublish the video when `setLocalVideoEnabled(false)` is called, we just stop it

The remote side is still getting that stream, it's just stuck. This PR makes it so that it's actually unpublished/republished so the remote side can handle it appropriately

Tested and worked on both iOS and Android