### PR TITLE
Fix camera mirror on Android

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -239,7 +239,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
 
                         @Override
                         public void onCameraSwitched() {
-
+                            setThumbnailMirror();
                         }
 
                         @Override
@@ -518,7 +518,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             CameraCapturer.CameraSource cameraSource = cameraCapturer.getCameraSource();
             final boolean isBackCamera = (cameraSource == CameraCapturer.CameraSource.BACK_CAMERA);
             if (thumbnailVideoView != null && thumbnailVideoView.getVisibility() == View.VISIBLE) {
-                thumbnailVideoView.setMirror(isBackCamera);
+                thumbnailVideoView.setMirror(!isBackCamera);
             }
         }
     }
@@ -526,7 +526,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     public void switchCamera() {
         if (cameraCapturer != null) {
             cameraCapturer.switchCamera();
-            setThumbnailMirror();
             CameraCapturer.CameraSource cameraSource = cameraCapturer.getCameraSource();
             final boolean isBackCamera = cameraSource == CameraCapturer.CameraSource.BACK_CAMERA;
             WritableMap event = new WritableNativeMap();


### PR DESCRIPTION
When the call starts, the thumbnail of the front camera is not mirrored.

The camera should only mirror if it's not the back camera, however in the PR https://github.com/blackuy/react-native-twilio-video-webrtc/pull/24, the behavior was reversed to be be mirrored only if it's the back camera when `setThumbnailMirror` is called. That makes sense when switching the camera, because the camera is not changed synchronously, so when `setThumbnailMirror` is called, the camera source has not changed yet, so if it says it's the back camera, it will actually switch to the front camera, and it will be mirrored.

The issue is that `setThumbnailMirror` is also called when the thumbnail is registered on `registerThumbnailVideoView` and it sets mirror to false, because it's not the back camera.

The change I'm proposing is to only mirror the camera if it's the front one, and calling `setMirror` in the `onCameraSwitched` event, because by that point, the camera source will be the correct one.
