### PR TITLE
Fix iOS camera mirror when camera starts

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -108,9 +108,6 @@ RCT_EXPORT_MODULE();
 
 - (void)addLocalView:(TVIVideoView *)view {
   [self.localVideoTrack addRenderer:view];
-  if (self.camera && self.camera.device.position == AVCaptureDevicePositionFront) {
-    view.mirror = true;
-  }
 }
 
 - (void)removeLocalView:(TVIVideoView *)view {
@@ -161,6 +158,11 @@ RCT_EXPORT_METHOD(startLocalVideo) {
           TVIVideoFormat *startFormat,
           NSError *error) {
       if (!error) {
+          if (self.camera && self.camera.device.position == AVCaptureDevicePositionFront) {
+              for (TVIVideoView *renderer in self.localVideoTrack.renderers) {
+                  renderer.mirror = mirror;
+              }
+          }
           [self sendEventCheckingListenerWithName:cameraDidStart body:nil];
       }
   }];

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -108,6 +108,9 @@ RCT_EXPORT_MODULE();
 
 - (void)addLocalView:(TVIVideoView *)view {
   [self.localVideoTrack addRenderer:view];
+  if (self.camera && self.camera.device.position == AVCaptureDevicePositionFront) {
+    view.mirror = true;
+  }
 }
 
 - (void)removeLocalView:(TVIVideoView *)view {


### PR DESCRIPTION
Fixes #297.

The problem is that the camera position is `AVCaptureDevicePositionUnspecified` when `addLocalView` is called, the solution I propose is to set the mirror when the camera starts, in the same way it's done when flipping the camera.