### PR TITLE
Add error message on android disconnected event

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -776,6 +776,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
                 }
                 event.putString("roomName", room.getName());
                 event.putString("roomSid", room.getSid());
+                if (e != null) {
+                  event.putString("error", e.getMessage());
+                }
                 pushEvent(CustomTwilioVideoView.this, ON_DISCONNECTED, event);
 
                 localParticipant = null;


### PR DESCRIPTION
Description:
iOS has `error` message in `onRoomDidDisconnect` event callback while android not having it. 

Similar issue: https://github.com/blackuy/react-native-twilio-video-webrtc/issues/290 (can't find any issue reported regarding `onRoomDidDisconnect`)

Tested this PR on android with `"error": "Room completed"` returned. (same as iOS, when room is terminated)