### PR TITLE
TS: Fix connect params

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,10 +75,21 @@ declare module "react-native-twilio-video-webrtc"{
     ref?: React.Ref<any>;
   };
 
+  type connectParams = {
+    accessToken: string;
+    roomName?: string;
+    encodingParameters?: {
+      enableH264Codec?: boolean;
+      // if audioBitrate OR videoBitrate is provided, you must provide both
+      audioBitrate?: number;
+      videoBitrate?: number;
+    }
+  }
+
   class TwilioVideo extends React.Component<TwilioVideoProps> {
     setLocalVideoEnabled: (enabled: boolean) => Promise<boolean>;
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
-    connect: (t: { roomName: string; accessToken: string; encodingParameters: object }) => void;
+    connect: (options: connectParams) => void;
     disconnect: () => void;
     flipCamera: () => void;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ declare module "react-native-twilio-video-webrtc"{
     ref?: React.Ref<any>;
   };
 
-  type connectParams = {
+  type iOSConnectParams = {
     accessToken: string;
     roomName?: string;
     encodingParameters?: {
@@ -86,10 +86,18 @@ declare module "react-native-twilio-video-webrtc"{
     }
   }
 
+  type androidConnectParams = {
+    roomName?: string;
+    accessToken: string;
+    enableAudio?: boolean;
+    enableVideo?: boolean;
+    enableRemoteAudio?: boolean;
+  }
+
   class TwilioVideo extends React.Component<TwilioVideoProps> {
     setLocalVideoEnabled: (enabled: boolean) => Promise<boolean>;
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
-    connect: (options: connectParams) => void;
+    connect: (options: iOSConnectParams | androidConnectParams) => void;
     disconnect: () => void;
     flipCamera: () => void;
   }


### PR DESCRIPTION
Current types are only for iOS, Android does not have an object as its third param, and the roomName and encodingParameters are optional. This should fix the typing for Android + iOS.