### PR TITLE
Fix hanging promise video not present

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -206,6 +206,9 @@ RCT_REMAP_METHOD(setLocalVideoEnabled, enabled:(BOOL)enabled setLocalVideoEnable
   if (self.localVideoTrack != nil) {
     [self.localVideoTrack setEnabled:enabled];
     resolve(@(enabled));
+  } else {
+    [self.localVideoTrack setEnabled:false];
+    resolve(@false);
   }
 }
 


### PR DESCRIPTION
If there is no video present on a device (like iOS simulator) and a user tries to perform any action of setLocalVideoEnabled (even setting it to false) causes a hanging promise. This sets localVideoTrack to false and resolves false.