### PR TITLE
Rotate video preview based on the VideoFrame.RotationAngle

### DIFF
--- a/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
+++ b/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
@@ -10,8 +10,7 @@ import android.content.Context;
 import android.graphics.Point;
 import android.view.View;
 import android.view.ViewGroup;
-
-import androidx.annotation.StringDef;
+import android.support.annotation.StringDef;
 
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;

--- a/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
+++ b/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
@@ -8,12 +8,25 @@ package com.twiliorn.library;
 
 import android.content.Context;
 import android.graphics.Point;
+import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.StringDef;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.twilio.video.VideoFrame;
 import com.twilio.video.VideoRenderer;
 import com.twilio.video.VideoScaleType;
 
 import org.webrtc.RendererCommon;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import static com.twiliorn.library.RNVideoViewGroup.Events.ON_FRAME_DIMENSIONS_CHANGED;
 
 public class RNVideoViewGroup extends ViewGroup {
     private PatchedVideoView surfaceViewRenderer = null;
@@ -21,12 +34,22 @@ public class RNVideoViewGroup extends ViewGroup {
     private int videoHeight = 0;
     private final Object layoutSync = new Object();
     private RendererCommon.ScalingType scalingType = RendererCommon.ScalingType.SCALE_ASPECT_FILL;
+    private final RCTEventEmitter eventEmitter;
 
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef({ON_FRAME_DIMENSIONS_CHANGED})
+    public @interface Events {
+        String ON_FRAME_DIMENSIONS_CHANGED = "onFrameDimensionsChanged";
+    }
 
-    public RNVideoViewGroup(Context context) {
-        super(context);
+    void pushEvent(View view, String name, WritableMap data) {
+        eventEmitter.receiveEvent(view.getId(), name, data);
+    }
 
-        surfaceViewRenderer = new PatchedVideoView(context);
+    public RNVideoViewGroup(ThemedReactContext themedReactContext) {
+        super(themedReactContext);
+        this.eventEmitter = themedReactContext.getJSModule(RCTEventEmitter.class);
+        surfaceViewRenderer = new PatchedVideoView(themedReactContext);
         surfaceViewRenderer.setVideoScaleType(VideoScaleType.ASPECT_FILL);
         addView(surfaceViewRenderer);
         surfaceViewRenderer.setListener(
@@ -39,9 +62,21 @@ public class RNVideoViewGroup extends ViewGroup {
                     @Override
                     public void onFrameDimensionsChanged(int vw, int vh, int rotation) {
                         synchronized (layoutSync) {
-                            videoHeight = vh;
-                            videoWidth = vw;
+                            if (rotation == VideoFrame.RotationAngle.ROTATION_90.getValue() ||
+                                    rotation == VideoFrame.RotationAngle.ROTATION_270.getValue()) {
+                                videoHeight = vw;
+                                videoWidth = vh;
+                            } else {
+                                videoHeight = vh;
+                                videoWidth = vw;
+                            }
                             RNVideoViewGroup.this.forceLayout();
+
+                            WritableMap event = new WritableNativeMap();
+                            event.putInt("height", vh);
+                            event.putInt("width", vw);
+                            event.putInt("rotation", rotation);
+                            pushEvent(RNVideoViewGroup.this, ON_FRAME_DIMENSIONS_CHANGED, event);
                         }
                     }
                 }

--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
@@ -7,7 +7,6 @@
 
 package com.twiliorn.library;
 
-import android.content.Context;
 import android.util.Log;
 
 import com.facebook.react.uimanager.ThemedReactContext;

--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
@@ -10,13 +10,15 @@ package com.twiliorn.library;
 import android.content.Context;
 import android.util.Log;
 
+import com.facebook.react.uimanager.ThemedReactContext;
+
 
 public class TwilioRemotePreview extends RNVideoViewGroup {
 
     private static final String TAG = "TwilioRemotePreview";
 
 
-    public TwilioRemotePreview(Context context, String trackSid) {
+    public TwilioRemotePreview(ThemedReactContext context, String trackSid) {
         super(context);
         Log.i("CustomTwilioVideoView", "Remote Prview Construct");
         Log.i("CustomTwilioVideoView", trackSid);

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
@@ -6,17 +6,19 @@
  */
 
 package com.twiliorn.library;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.ThemedReactContext;
 
 import android.content.Context;
-
 
 public class TwilioVideoPreview extends RNVideoViewGroup {
 
     private static final String TAG = "TwilioVideoPreview";
 
-    public TwilioVideoPreview(Context context) {
-        super(context);
+    public TwilioVideoPreview(ThemedReactContext themedReactContext) {
+        super(themedReactContext);
         CustomTwilioVideoView.registerThumbnailVideoView(this.getSurfaceViewRenderer());
+        this.getSurfaceViewRenderer().setMirror(true);
         this.getSurfaceViewRenderer().applyZOrder(true);
     }
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
@@ -18,7 +18,6 @@ public class TwilioVideoPreview extends RNVideoViewGroup {
     public TwilioVideoPreview(ThemedReactContext themedReactContext) {
         super(themedReactContext);
         CustomTwilioVideoView.registerThumbnailVideoView(this.getSurfaceViewRenderer());
-        this.getSurfaceViewRenderer().setMirror(true);
         this.getSurfaceViewRenderer().applyZOrder(true);
     }
 }

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
@@ -9,8 +9,6 @@ package com.twiliorn.library;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.ThemedReactContext;
 
-import android.content.Context;
-
 public class TwilioVideoPreview extends RNVideoViewGroup {
 
     private static final String TAG = "TwilioVideoPreview";

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
@@ -7,7 +7,7 @@
 
 package com.twiliorn.library;
 
-import androidx.annotation.Nullable;
+import android.support.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreviewManager.java
@@ -7,7 +7,7 @@
 
 package com.twiliorn.library;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
@@ -18,6 +18,8 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import java.util.Map;
 
 import org.webrtc.RendererCommon;
+
+import static com.twiliorn.library.RNVideoViewGroup.Events.ON_FRAME_DIMENSIONS_CHANGED;
 
 public class TwilioVideoPreviewManager extends SimpleViewManager<TwilioVideoPreview> {
 
@@ -35,6 +37,16 @@ public class TwilioVideoPreviewManager extends SimpleViewManager<TwilioVideoPrev
       } else {
         view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);
       }
+    }
+
+    @Override
+    @Nullable
+    public Map getExportedCustomDirectEventTypeConstants() {
+        Map<String, Map<String, String>> map = MapBuilder.of(
+                ON_FRAME_DIMENSIONS_CHANGED, MapBuilder.of("registrationName", ON_FRAME_DIMENSIONS_CHANGED)
+        );
+
+        return map;
     }
 
     @Override

--- a/src/TwilioVideoParticipantView.android.js
+++ b/src/TwilioVideoParticipantView.android.js
@@ -31,7 +31,7 @@ class TwilioRemotePreview extends React.Component {
 
   buildNativeEventWrappers () {
     return [
-      'onFrameDimensionsChanged',
+      'onFrameDimensionsChanged'
     ].reduce((wrappedEvents, eventName) => {
       if (this.props[eventName]) {
         return {

--- a/src/TwilioVideoParticipantView.android.js
+++ b/src/TwilioVideoParticipantView.android.js
@@ -17,6 +17,7 @@ class TwilioRemotePreview extends React.Component {
        */
       videoTrackSid: PropTypes.string.isRequired
     }),
+    onFrameDimensionsChanged: PropTypes.func,
     trackSid: PropTypes.string,
     renderToHardwareTextureAndroid: PropTypes.string,
     onLayout: PropTypes.string,
@@ -28,12 +29,27 @@ class TwilioRemotePreview extends React.Component {
     testID: PropTypes.string
   }
 
+  buildNativeEventWrappers () {
+    return [
+      'onFrameDimensionsChanged',
+    ].reduce((wrappedEvents, eventName) => {
+      if (this.props[eventName]) {
+        return {
+          ...wrappedEvents,
+          [eventName]: data => this.props[eventName](data.nativeEvent)
+        }
+      }
+      return wrappedEvents
+    }, {})
+  }
+
   render () {
     const { trackIdentifier } = this.props
     return (
       <NativeTwilioRemotePreview
         trackSid={trackIdentifier && trackIdentifier.videoTrackSid}
         {...this.props}
+        {...this.buildNativeEventWrappers()}
       />
     )
   }


### PR DESCRIPTION
I've found that when the RotationAngle on the `onFrameDimensionsChanged` callback is any of `90` or `270`, the dimensions are inverted, e.g. if the other participant has a 720 (width) x 1280 (height) stream, the width and height in the `onFrameDimensionsChanged` are 1280 and 720 respectively.

I've been able to recreate this when calling from iOS Safari to a native android app. The participant in Safari sends a portrait stream, and the android app displays it as a landscape one with most of the content cropped.

The solution I found is to check the rotation angle and set the `videoWidth` and  `videoHeight` accordingly. This fixed the issue partially, because if the other participant rotates their device, the `RotationAngle` in `onFrameDimensionsChanged` changes, but `onLayout` is not called, ending up with a cut off stream again.

I'm using a solution based on this https://github.com/blackuy/react-native-twilio-video-webrtc/issues/241#issue-507940343 to force `onLayout` to run from React Native, so I added an event to `TwilioVideoParticipantView.android.js` that is called with the values of the native `onFrameDimensionsChanged` event, and force `onLayout` in the event handler.