### PR TITLE
Include local participant for connect event on android

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -711,6 +711,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
                 for (RemoteParticipant participant : participants) {
                     participantsArray.pushMap(buildParticipant(participant));
                 }
+                participantsArray.pushMap(buildParticipant(localParticipant));
                 event.putArray("participants", participantsArray);
 
                 pushEvent(CustomTwilioVideoView.this, ON_CONNECTED, event);


### PR DESCRIPTION
iOS implementation at the moment includes local participant in participants array for the connect event and also triggers on participant connected event for itself. Android doesn't to it, it only takes remote participants into account.

With this PR I also add local participant for Android so it's consistent with iOS implementation.

iOS implementation reference is here: https://github.com/blackuy/react-native-twilio-video-webrtc/blob/master/ios/RCTTWVideoModule.m#L445