### PR TITLE
Publish/unpublish track methods for Android

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jul 14 01:42:45 PKT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -586,6 +586,26 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         }
     }
 
+    public void publishLocalVideo(boolean enabled) {
+        if (localParticipant != null && localVideoTrack != null) {
+            if (enabled) {
+                localParticipant.publishTrack(localVideoTrack);
+            } else {
+                localParticipant.unpublishTrack(localVideoTrack);
+            }
+        }
+    }
+
+    public void publishLocalAudio(boolean enabled) {
+        if (localParticipant != null && localAudioTrack != null) {
+            if (enabled) {
+                localParticipant.publishTrack(localAudioTrack);
+            } else {
+                localParticipant.unpublishTrack(localAudioTrack);
+            }
+        }
+    }
+
 
     private void convertBaseTrackStats(BaseTrackStats bs, WritableMap result) {
         result.putString("codec", bs.codec);

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -55,6 +55,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     private static final int RELEASE_RESOURCE = 10;
     private static final int TOGGLE_BLUETOOTH_HEADSET = 11;
     private static final int SEND_STRING = 12;
+    private static final int PUBLISH_VIDEO = 13;
+    private static final int PUBLISH_AUDIO = 14;
 
     @Override
     public String getName() {
@@ -114,6 +116,12 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 break;
             case SEND_STRING:
                 view.sendString(args.getString(0));
+                break;
+            case PUBLISH_VIDEO:
+                view.publishLocalVideo(args.getBoolean(0));
+                break;
+            case PUBLISH_AUDIO:
+                view.publishLocalAudio(args.getBoolean(0));
                 break;
         }
     }

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -149,7 +149,9 @@ const nativeEvents = {
   toggleRemoteSound: 9,
   releaseResource: 10,
   toggleBluetoothHeadset: 11,
-  sendString: 12
+  sendString: 12,
+  publishVideo: 13,
+  publishAudio: 14,
 }
 
 class CustomTwilioVideoView extends Component {
@@ -173,6 +175,22 @@ class CustomTwilioVideoView extends Component {
     this.runCommand(nativeEvents.sendString, [
       message
     ])
+  }
+
+  publishLocalAudio () {
+    this.runCommand(nativeEvents.publishAudio, [true])
+  }
+
+  publishLocalVideo () {
+    this.runCommand(nativeEvents.publishVideo, [true])
+  }
+
+  unpublishLocalAudio () {
+    this.runCommand(nativeEvents.publishAudio, [false])
+  }
+
+  unpublishLocalVideo () {
+    this.runCommand(nativeEvents.publishVideo, [false])
   }
 
   disconnect () {

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -151,7 +151,7 @@ const nativeEvents = {
   toggleBluetoothHeadset: 11,
   sendString: 12,
   publishVideo: 13,
-  publishAudio: 14,
+  publishAudio: 14
 }
 
 class CustomTwilioVideoView extends Component {

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -148,19 +148,6 @@ export default class extends Component {
 
     this._subscriptions = []
     this._eventEmitter = new NativeEventEmitter(TWVideoModule)
-
-    this.setLocalVideoEnabled = this.setLocalVideoEnabled.bind(this)
-    this.setLocalAudioEnabled = this.setLocalAudioEnabled.bind(this)
-    this.flipCamera = this.flipCamera.bind(this)
-    this.connect = this.connect.bind(this)
-    this.disconnect = this.disconnect.bind(this)
-    this.sendString = this.sendString.bind(this)
-    this.setRemoteAudioPlayback = this.setRemoteAudioPlayback.bind(this)
-    this.unpublishLocalAudio = this.unpublishLocalAudio.bind(this)
-    this.unpublishLocalVideo = this.unpublishLocalVideo.bind(this)
-
-    this.publishLocalAudio = this.publishLocalAudio.bind(this)
-    this.publishLocalVideo = this.publishLocalVideo.bind(this)
   }
 
   componentWillMount () {


### PR DESCRIPTION
Included in this PR:

- Gradle Upgrade (requested by Android Studio)
- Unnecessary binds in `TwilioVideo.ios.js` (the bound methods weren't using `this` anywhere in them, so bind was unnecessary)
- Add `{,un}publishLocal{Audio,Video}` methods for Android

Tested on S8+ to work as expected

Fixes https://github.com/blackuy/react-native-twilio-video-webrtc/issues/350