### PR TITLE
Update twilio-video-ios to 3.7 for iOS 14

### DIFF
--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 3.7.0'
+  s.dependency 'TwilioVideo', '~> 3.7'
 end

--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 3.2.3'
+  s.dependency 'TwilioVideo', '~> 3.7.0'
 end


### PR DESCRIPTION
This PR updates the pod for iOS 14 support. Full details on the change are here:

https://www.twilio.com/docs/video/changelog-twilio-video-ios-version-3x

Basically it removes the need for a new NetworkPrivacyPolicy request and removes local networking for peer-to-peer rooms.

Tests locally on a localhost with two phones, works without a problem.

Solved #376 