### PR TITLE
README _onParticipantRemovedVideoTrack bugfix

### DIFF
--- a/Example/index.js
+++ b/Example/index.js
@@ -152,10 +152,10 @@ export default class Example extends Component {
   _onParticipantRemovedVideoTrack = ({participant, track}) => {
     console.log("onParticipantRemovedVideoTrack: ", participant, track)
 
-    const videoTracks = this.state.videoTracks
+    const videoTracks = new Map(this.state.videoTracks);
     videoTracks.delete(track.trackSid)
 
-    this.setState({ videoTracks: new Map([ ...videoTracks ]) });
+    this.setState({ videoTracks });
   }
 
   _requestAudioPermission =  () => {

--- a/README.md
+++ b/README.md
@@ -278,10 +278,10 @@ export default class Example extends Component {
   _onParticipantRemovedVideoTrack = ({participant, track}) => {
     console.log("onParticipantRemovedVideoTrack: ", participant, track)
 
-    const videoTracks = this.state.videoTracks
+    const videoTracks = new Map(this.state.videoTracks)
     videoTracks.delete(track.trackSid)
 
-    this.setState({videoTracks: { ...videoTracks }})
+    this.setState({videoTracks})
   }
 
   render() {


### PR DESCRIPTION
This fixes a bug in the README example where `_onParticipantRemovedVideoTrack` directly manipulates state and then replaces the videoTracks Map with an object. Turning videoTacks into an object causes errors when adding or removing more tracks.

Thanks for a great package! 🌟