### PR TITLE
conditionally republish video on resume

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -164,6 +164,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
      */
     private static PatchedVideoView thumbnailVideoView;
     private static LocalVideoTrack localVideoTrack;
+    private boolean isLocalVideoPublished = false;
 
     private static CameraCapturer cameraCapturer;
     private LocalAudioTrack localAudioTrack;
@@ -301,7 +302,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
                 /*
                  * If connected to a Room then share the local video track.
                  */
-                if (localParticipant != null) {
+                if (localParticipant != null && isLocalVideoPublished) {
                     localParticipant.publishTrack(localVideoTrack);
                 }
             }
@@ -588,6 +589,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
 
     public void publishLocalVideo(boolean enabled) {
         if (localParticipant != null && localVideoTrack != null) {
+            isLocalVideoPublished = enabled;
             if (enabled) {
                 localParticipant.publishTrack(localVideoTrack);
             } else {


### PR DESCRIPTION
When app returns from background, video should only be republished if it was published before.
Unconditionally publishing video upon returning to the app can be unwanted behavior for apps that need local video to be unpublished.