### PR TITLE
Add network quality reporting

### DIFF
--- a/Example/index.js
+++ b/Example/index.js
@@ -35,7 +35,7 @@ const Example = (props) => {
       await this._requestAudioPermission();
       await this._requestCameraPermission();
     }
-    twilioVideo.current.connect({ accessToken: this.state.token });
+    twilioVideo.current.connect({ accessToken: token, enableNetworkQualityReporting: true});
     setStatus("connecting");
   };
 
@@ -91,6 +91,11 @@ const Example = (props) => {
 
     setVideoTracks(videoTracks);
   };
+
+  const _onNetworkLevelChanged = ({ participant, isLocalUser, quality }) => {
+    console.log("Participant", participant, "isLocalUser", isLocalUser, "quality", quality);
+  };
+
 
   const _requestAudioPermission = () => {
     return PermissionsAndroid.request(
@@ -181,6 +186,7 @@ const Example = (props) => {
         onRoomDidFailToConnect={_onRoomDidFailToConnect}
         onParticipantAddedVideoTrack={_onParticipantAddedVideoTrack}
         onParticipantRemovedVideoTrack={_onParticipantRemovedVideoTrack}
+        onNetworkQualityLevelsChanged={_onNetworkLevelChanged}
       />
     </View>
   );

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -39,11 +39,17 @@ import com.twilio.video.BaseTrackStats;
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.ConnectOptions;
 import com.twilio.video.LocalAudioTrack;
+import com.twilio.video.LocalAudioTrackPublication;
 import com.twilio.video.LocalAudioTrackStats;
+import com.twilio.video.LocalDataTrackPublication;
 import com.twilio.video.LocalParticipant;
 import com.twilio.video.LocalTrackStats;
 import com.twilio.video.LocalVideoTrack;
+import com.twilio.video.LocalVideoTrackPublication;
 import com.twilio.video.LocalVideoTrackStats;
+import com.twilio.video.NetworkQualityConfiguration;
+import com.twilio.video.NetworkQualityLevel;
+import com.twilio.video.NetworkQualityVerbosity;
 import com.twilio.video.Participant;
 import com.twilio.video.RemoteAudioTrack;
 import com.twilio.video.RemoteAudioTrackPublication;
@@ -79,6 +85,7 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_CONNECTED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_CONNECT_FAILURE;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DISCONNECTED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DATATRACK_MESSAGE_RECEIVED;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_NETWORK_QUALITY_LEVELS_CHANGED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_DATA_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_AUDIO_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_VIDEO_TRACK;
@@ -98,6 +105,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     private static final String TAG = "CustomTwilioVideoView";
     private static final String DATA_TRACK_MESSAGE_THREAD_NAME = "DataTrackMessages";
     private boolean enableRemoteAudio = false;
+    private boolean enableNetworkQualityReporting = false;
     private boolean isVideoEnabled = false;
 
     @Retention(RetentionPolicy.SOURCE)
@@ -120,7 +128,8 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             Events.ON_PARTICIPANT_DISABLED_VIDEO_TRACK,
             Events.ON_PARTICIPANT_ENABLED_AUDIO_TRACK,
             Events.ON_PARTICIPANT_DISABLED_AUDIO_TRACK,
-            Events.ON_STATS_RECEIVED})
+            Events.ON_STATS_RECEIVED,
+            Events.ON_NETWORK_QUALITY_LEVELS_CHANGED})
     public @interface Events {
         String ON_CAMERA_SWITCHED = "onCameraSwitched";
         String ON_VIDEO_CHANGED = "onVideoChanged";
@@ -142,6 +151,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         String ON_PARTICIPANT_ENABLED_AUDIO_TRACK = "onParticipantEnabledAudioTrack";
         String ON_PARTICIPANT_DISABLED_AUDIO_TRACK = "onParticipantDisabledAudioTrack";
         String ON_STATS_RECEIVED = "onStatsReceived";
+        String ON_NETWORK_QUALITY_LEVELS_CHANGED = "onNetworkQualityLevelsChanged";
     }
 
     private final ThemedReactContext themedReactContext;
@@ -375,10 +385,12 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     // ====== CONNECTING ===========================================================================
 
     public void connectToRoomWrapper(
-            String roomName, String accessToken, boolean enableAudio, boolean enableVideo, boolean enableRemoteAudio) {
+            String roomName, String accessToken, boolean enableAudio, boolean enableVideo,
+            boolean enableRemoteAudio, boolean enableNetworkQualityReporting) {
         this.roomName = roomName;
         this.accessToken = accessToken;
         this.enableRemoteAudio = enableAudio;
+        this.enableNetworkQualityReporting = enableNetworkQualityReporting;
 
         // Share your microphone
         localAudioTrack = LocalAudioTrack.create(getContext(), enableAudio);
@@ -417,6 +429,13 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
          if (localDataTrack != null) {
             connectOptionsBuilder.dataTracks(Collections.singletonList(localDataTrack));
         }
+
+         if (enableNetworkQualityReporting) {
+             connectOptionsBuilder.enableNetworkQuality(true);
+             connectOptionsBuilder.networkQualityConfiguration(new NetworkQualityConfiguration(
+                     NetworkQualityVerbosity.NETWORK_QUALITY_VERBOSITY_MINIMAL,
+                     NetworkQualityVerbosity.NETWORK_QUALITY_VERBOSITY_MINIMAL));
+         }
 
         room = Video.connect(getContext(), connectOptionsBuilder.build(), roomListener());
     }
@@ -724,6 +743,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             @Override
             public void onConnected(Room room) {
                 localParticipant = room.getLocalParticipant();
+                localParticipant.setListener(localListener());
 
                 WritableMap event = new WritableNativeMap();
                 event.putString("roomName", room.getName());
@@ -970,6 +990,66 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             public void onVideoTrackDisabled(RemoteParticipant participant, RemoteVideoTrackPublication publication) {
                 WritableMap event = buildParticipantVideoEvent(participant, publication);
                 pushEvent(CustomTwilioVideoView.this, ON_PARTICIPANT_DISABLED_VIDEO_TRACK, event);
+            }
+
+            @Override
+            public void onNetworkQualityLevelChanged(@androidx.annotation.NonNull RemoteParticipant remoteParticipant, @androidx.annotation.NonNull NetworkQualityLevel networkQualityLevel) {
+                WritableMap event = new WritableNativeMap();
+                event.putMap("participant", buildParticipant(remoteParticipant));
+                event.putBoolean("isLocalUser", false);
+
+                // Twilio SDK defines Enum 0 as UNKNOWN and 1 as Quality ZERO, so we subtract one to get the correct quality level as an integer
+                event.putInt("quality", networkQualityLevel.ordinal() - 1);
+
+                pushEvent(CustomTwilioVideoView.this, ON_NETWORK_QUALITY_LEVELS_CHANGED, event);
+            }
+        };
+    }
+
+    // ====== LOCAL LISTENER =======================================================================
+    private LocalParticipant.Listener localListener() {
+        return new LocalParticipant.Listener() {
+
+            @Override
+            public void onAudioTrackPublished(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalAudioTrackPublication localAudioTrackPublication) {
+
+            }
+
+            @Override
+            public void onAudioTrackPublicationFailed(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalAudioTrack localAudioTrack, @androidx.annotation.NonNull TwilioException twilioException) {
+
+            }
+
+            @Override
+            public void onVideoTrackPublished(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalVideoTrackPublication localVideoTrackPublication) {
+
+            }
+
+            @Override
+            public void onVideoTrackPublicationFailed(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalVideoTrack localVideoTrack, @androidx.annotation.NonNull TwilioException twilioException) {
+
+            }
+
+            @Override
+            public void onDataTrackPublished(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalDataTrackPublication localDataTrackPublication) {
+
+            }
+
+            @Override
+            public void onDataTrackPublicationFailed(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalDataTrack localDataTrack, @androidx.annotation.NonNull TwilioException twilioException) {
+
+            }
+
+            @Override
+            public void onNetworkQualityLevelChanged(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull NetworkQualityLevel networkQualityLevel) {
+                WritableMap event = new WritableNativeMap();
+                event.putMap("participant", buildParticipant(localParticipant));
+                event.putBoolean("isLocalUser", true);
+
+                // Twilio SDK defines Enum 0 as UNKNOWN and 1 as Quality ZERO, so we subtract one to get the correct quality level as an integer
+                event.putInt("quality", networkQualityLevel.ordinal() - 1);
+
+                pushEvent(CustomTwilioVideoView.this, ON_NETWORK_QUALITY_LEVELS_CHANGED, event);
             }
         };
     }

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -993,7 +993,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             }
 
             @Override
-            public void onNetworkQualityLevelChanged(@androidx.annotation.NonNull RemoteParticipant remoteParticipant, @androidx.annotation.NonNull NetworkQualityLevel networkQualityLevel) {
+            public void onNetworkQualityLevelChanged(RemoteParticipant remoteParticipant, NetworkQualityLevel networkQualityLevel) {
                 WritableMap event = new WritableNativeMap();
                 event.putMap("participant", buildParticipant(remoteParticipant));
                 event.putBoolean("isLocalUser", false);
@@ -1011,37 +1011,37 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         return new LocalParticipant.Listener() {
 
             @Override
-            public void onAudioTrackPublished(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalAudioTrackPublication localAudioTrackPublication) {
+            public void onAudioTrackPublished(LocalParticipant localParticipant, LocalAudioTrackPublication localAudioTrackPublication) {
 
             }
 
             @Override
-            public void onAudioTrackPublicationFailed(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalAudioTrack localAudioTrack, @androidx.annotation.NonNull TwilioException twilioException) {
+            public void onAudioTrackPublicationFailed(LocalParticipant localParticipant, LocalAudioTrack localAudioTrack, TwilioException twilioException) {
 
             }
 
             @Override
-            public void onVideoTrackPublished(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalVideoTrackPublication localVideoTrackPublication) {
+            public void onVideoTrackPublished(LocalParticipant localParticipant, LocalVideoTrackPublication localVideoTrackPublication) {
 
             }
 
             @Override
-            public void onVideoTrackPublicationFailed(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalVideoTrack localVideoTrack, @androidx.annotation.NonNull TwilioException twilioException) {
+            public void onVideoTrackPublicationFailed(LocalParticipant localParticipant, LocalVideoTrack localVideoTrack, TwilioException twilioException) {
 
             }
 
             @Override
-            public void onDataTrackPublished(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalDataTrackPublication localDataTrackPublication) {
+            public void onDataTrackPublished(LocalParticipant localParticipant, LocalDataTrackPublication localDataTrackPublication) {
 
             }
 
             @Override
-            public void onDataTrackPublicationFailed(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull LocalDataTrack localDataTrack, @androidx.annotation.NonNull TwilioException twilioException) {
+            public void onDataTrackPublicationFailed(LocalParticipant localParticipant, LocalDataTrack localDataTrack, TwilioException twilioException) {
 
             }
 
             @Override
-            public void onNetworkQualityLevelChanged(@androidx.annotation.NonNull LocalParticipant localParticipant, @androidx.annotation.NonNull NetworkQualityLevel networkQualityLevel) {
+            public void onNetworkQualityLevelChanged(LocalParticipant localParticipant, NetworkQualityLevel networkQualityLevel) {
                 WritableMap event = new WritableNativeMap();
                 event.putMap("participant", buildParticipant(localParticipant));
                 event.putBoolean("isLocalUser", true);

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -98,6 +98,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     private static final String TAG = "CustomTwilioVideoView";
     private static final String DATA_TRACK_MESSAGE_THREAD_NAME = "DataTrackMessages";
     private boolean enableRemoteAudio = false;
+    private boolean isVideoEnabled = false;
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({Events.ON_CAMERA_SWITCHED,
@@ -255,6 +256,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     }
 
     private boolean createLocalVideo(boolean enableVideo) {
+      isVideoEnabled = enableVideo;
         // Share your camera
         cameraCapturer = this.createCameraCaputer(getContext(), CameraCapturer.CameraSource.FRONT_CAMERA);
         if (cameraCapturer == null){
@@ -290,7 +292,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
              * If the local video track was released when the app was put in the background, recreate.
              */
             if (cameraCapturer != null && localVideoTrack == null) {
-                localVideoTrack = LocalVideoTrack.create(getContext(), true, cameraCapturer, buildVideoConstraints());
+                localVideoTrack = LocalVideoTrack.create(getContext(), isVideoEnabled, cameraCapturer, buildVideoConstraints());
             }
 
             if (localVideoTrack != null) {
@@ -537,6 +539,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     }
 
     public void toggleVideo(boolean enabled) {
+      isVideoEnabled = enabled;
         if (localVideoTrack != null) {
             localVideoTrack.enable(enabled);
 

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -38,6 +38,7 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_D
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ENABLED_AUDIO_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_DISABLED_AUDIO_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_STATS_RECEIVED;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_NETWORK_QUALITY_LEVELS_CHANGED;
 
 
 public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilioVideoView> {
@@ -77,7 +78,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 boolean enableAudio = args.getBoolean(2);
                 boolean enableVideo = args.getBoolean(3);
                 boolean enableRemoteAudio = args.getBoolean(4);
-                view.connectToRoomWrapper(roomName, accessToken, enableAudio, enableVideo, enableRemoteAudio);
+                boolean enableNetworkQualityReporting = args.getBoolean(5);
+                view.connectToRoomWrapper(roomName, accessToken, enableAudio, enableVideo, enableRemoteAudio, enableNetworkQualityReporting);
                 break;
             case DISCONNECT:
                 view.disconnect();
@@ -158,7 +160,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 ON_PARTICIPANT_DISABLED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_DISABLED_VIDEO_TRACK),
                 ON_PARTICIPANT_ENABLED_AUDIO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ENABLED_AUDIO_TRACK),
                 ON_PARTICIPANT_DISABLED_AUDIO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_DISABLED_AUDIO_TRACK),
-                ON_STATS_RECEIVED, MapBuilder.of("registrationName", ON_STATS_RECEIVED)
+                ON_STATS_RECEIVED, MapBuilder.of("registrationName", ON_STATS_RECEIVED),
+                ON_NETWORK_QUALITY_LEVELS_CHANGED, MapBuilder.of("registrationName", ON_NETWORK_QUALITY_LEVELS_CHANGED)
         ));
 
         return map;

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,12 @@ declare module "react-native-twilio-video-webrtc"{
   export type RoomErrorEventCb = (t: RoomErrorEventArgs) => void;
 
   export type ParticipantEventCb = (p: ParticipantEventArgs) => void;
+  
+  export interface NetworkLevelChangeEventCb {
+    participant: Participant;
+    isLocalUser: boolean;
+    qualityLevel: string;
+  };
 
   type TwilioVideoProps = ViewProps & {
     onCameraDidStart?: () => void;
@@ -72,6 +78,8 @@ declare module "react-native-twilio-video-webrtc"{
     onRoomDidFailToConnect?: RoomErrorEventCb;
     onRoomParticipantDidConnect?: ParticipantEventCb;
     onRoomParticipantDidDisconnect?: ParticipantEventCb;
+    onNetworkQualityLevelsChanged?: NetworkLevelChangeEventCb;
+
     ref?: React.Ref<any>;
   };
 
@@ -86,6 +94,7 @@ declare module "react-native-twilio-video-webrtc"{
       audioBitrate?: number;
       videoBitrate?: number;
     }
+    enableNetworkQualityReporting?: boolean;
   }
 
   type androidConnectParams = {
@@ -94,6 +103,7 @@ declare module "react-native-twilio-video-webrtc"{
     enableAudio?: boolean;
     enableVideo?: boolean;
     enableRemoteAudio?: boolean;
+    enableNetworkQualityReporting?: boolean;
   }
 
   class TwilioVideo extends React.Component<TwilioVideoProps> {

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -33,6 +33,7 @@ static NSString* cameraWasInterrupted         = @"cameraWasInterrupted";
 static NSString* cameraInterruptionEnded      = @"cameraInterruptionEnded";
 static NSString* cameraDidStopRunning         = @"cameraDidStopRunning";
 static NSString* statsReceived                = @"statsReceived";
+static NSString* networkQualityLevelsChanged  = @"networkQualityLevelsChanged";
 
 static const CMVideoDimensions kRCTTWVideoAppCameraSourceDimensions = (CMVideoDimensions){900, 720};
 
@@ -59,7 +60,7 @@ TVIVideoFormat *RCTTWVideoModuleCameraSourceSelectVideoFormatBySize(AVCaptureDev
 }
 
 
-@interface RCTTWVideoModule () <TVIRemoteDataTrackDelegate, TVIRemoteParticipantDelegate, TVIRoomDelegate, TVICameraSourceDelegate>
+@interface RCTTWVideoModule () <TVIRemoteDataTrackDelegate, TVIRemoteParticipantDelegate, TVIRoomDelegate, TVICameraSourceDelegate, TVILocalParticipantDelegate>
 
 @property (strong, nonatomic) TVICameraSource *camera;
 @property (strong, nonatomic) TVILocalVideoTrack* localVideoTrack;
@@ -107,7 +108,8 @@ RCT_EXPORT_MODULE();
     cameraDidStart,
     cameraWasInterrupted,
     cameraInterruptionEnded,
-    statsReceived
+    statsReceived,
+    networkQualityLevelsChanged
   ];
 }
 
@@ -387,7 +389,7 @@ RCT_EXPORT_METHOD(getStats) {
     }
 }
 
-RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters) {
+RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting) {
 
   [self enableLocalVideoAtCreationTime: enableVideo];
 
@@ -419,6 +421,11 @@ RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName 
       builder.encodingParameters = [[TVIEncodingParameters alloc] initWithAudioBitrate:(audioBitrate) ? audioBitrate : 40 videoBitrate:(videoBitrate) ? videoBitrate : 1500];
     }
       
+    if (enableNetworkQualityReporting) {
+      builder.networkQualityEnabled = true;
+      builder.networkQualityConfiguration = [ [TVINetworkQualityConfiguration alloc] initWithLocalVerbosity:TVINetworkQualityVerbosityMinimal remoteVerbosity:TVINetworkQualityVerbosityMinimal];
+    }
+  
   }];
 
   self.room = [TwilioVideoSDK connectWithOptions:connectOptions delegate:self];
@@ -494,6 +501,8 @@ RCT_EXPORT_METHOD(disconnect) {
     [participants addObject:[p toJSON]];
   }
   self.localParticipant = room.localParticipant;
+  self.localParticipant.delegate = self;
+    
   [participants addObject:[self.localParticipant toJSON]];
   [self sendEventCheckingListenerWithName:roomDidConnect body:@{ @"roomName" : room.name , @"roomSid": room.sid, @"participants" : participants }];
 
@@ -578,6 +587,10 @@ RCT_EXPORT_METHOD(disconnect) {
     [self sendEventCheckingListenerWithName:participantDisabledAudioTrack body:@{ @"participant": [participant toJSON], @"track": [publication toJSON] }];
 }
 
+- (void)remoteParticipant:(nonnull TVIRemoteParticipant *)participant networkQualityLevelDidChange:(TVINetworkQualityLevel)networkQualityLevel {
+    [self sendEventCheckingListenerWithName:networkQualityLevelsChanged body:@{ @"participant": [participant toJSON], @"isLocalUser": [NSNumber numberWithBool:false], @"quality": [NSNumber numberWithInt:(int)networkQualityLevel]}];
+}
+
 # pragma mark - TVIRemoteDataTrackDelegate
 
 - (void)remoteDataTrack:(nonnull TVIRemoteDataTrack *)remoteDataTrack didReceiveString:(nonnull NSString *)message {
@@ -589,8 +602,10 @@ RCT_EXPORT_METHOD(disconnect) {
     NSLog(@"DataTrack didReceiveData");
 }
 
+# pragma mark - TVILocalParticipantDelegate
 
-
-// TODO: Local participant delegates
+- (void)localParticipant:(nonnull TVILocalParticipant *)participant networkQualityLevelDidChange:(TVINetworkQualityLevel)networkQualityLevel {
+    [self sendEventCheckingListenerWithName:networkQualityLevelsChanged body:@{ @"participant": [participant toJSON], @"isLocalUser": [NSNumber numberWithBool:true], @"quality": [NSNumber numberWithInt:(int)networkQualityLevel]}];
+}
 
 @end

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -134,7 +134,11 @@ const propTypes = {
   /**
    * Callback that is called when stats are received (after calling getStats)
    */
-  onStatsReceived: PropTypes.func
+  onStatsReceived: PropTypes.func,
+  /**
+   * Callback that is called when network quality levels are changed (only if enableNetworkQualityReporting in connect is set to true)
+   */
+  onNetworkQualityLevelsChanged: PropTypes.func
 }
 
 const nativeEvents = {
@@ -160,14 +164,16 @@ class CustomTwilioVideoView extends Component {
     accessToken,
     enableAudio = true,
     enableVideo = true,
-    enableRemoteAudio = true
+    enableRemoteAudio = true,
+    enableNetworkQualityReporting = false
   }) {
     this.runCommand(nativeEvents.connectToRoom, [
       roomName,
       accessToken,
       enableAudio,
       enableVideo,
-      enableRemoteAudio
+      enableRemoteAudio,
+      enableNetworkQualityReporting
     ])
   }
 
@@ -272,7 +278,8 @@ class CustomTwilioVideoView extends Component {
       'onParticipantDisabledVideoTrack',
       'onParticipantEnabledAudioTrack',
       'onParticipantDisabledAudioTrack',
-      'onStatsReceived'
+      'onStatsReceived',
+      'onNetworkQualityLevelsChanged'
     ].reduce((wrappedEvents, eventName) => {
       if (this.props[eventName]) {
         return {

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -140,6 +140,11 @@ export default class extends Component {
      *
      */
     onStatsReceived: PropTypes.func,
+    /**
+     * Called when the network quality levels of a participant have changed (only if enableNetworkQualityReporting is set to True when connecting)
+     *
+     */
+    onNetworkQualityLevelsChanged: PropTypes.func,
     ...View.propTypes
   }
 
@@ -216,9 +221,10 @@ export default class extends Component {
    * @param  {String} roomName    The connecting room name
    * @param  {String} accessToken The Twilio's JWT access token
    * @param  {String} encodingParameters Control Encoding config
+   * @param  {Boolean} enableNetworkQualityReporting Report network quality of participants
    */
-  connect ({ roomName, accessToken, enableVideo = true, encodingParameters }) {
-    TWVideoModule.connect(accessToken, roomName, enableVideo, encodingParameters)
+  connect ({ roomName, accessToken, enableVideo = true, encodingParameters = null, enableNetworkQualityReporting = false }) {
+    TWVideoModule.connect(accessToken, roomName, enableVideo, encodingParameters, enableNetworkQualityReporting)
   }
 
   /**
@@ -392,6 +398,11 @@ export default class extends Component {
       this._eventEmitter.addListener('statsReceived', data => {
         if (this.props.onStatsReceived) {
           this.props.onStatsReceived(data)
+        }
+      }),
+      this._eventEmitter.addListener('networkQualityLevelsChanged', data => {
+        if (this.props.onNetworkQualityLevelsChanged) {
+          this.props.onNetworkQualityLevelsChanged(data)
         }
       })
     ]


### PR DESCRIPTION
Adds support for Network Quality Reporting as per Twilio docs: https://www.twilio.com/docs/video/using-network-quality-api

I have tried to keep the changes as minimal as possible and add support for network quality reporting of local and remote participants.

Network Quality Reporting is disabled by default so existing users shouldn't see any difference unless explicitly enabled.