### PR TITLE
Reference local SDK in Example instead of the Github version

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -15,7 +15,7 @@
     "babel-jest": "24.8.0",
     "jest": "24.8.0",
     "metro-react-native-babel-preset": "^0.51.1",
-    "react-native-twilio-video-webrtc": "github:blackuy/react-native-twilio-video-webrtc",
+    "react-native-twilio-video-webrtc": "file:../",
     "react-test-renderer": "16.8.3"
   },
   "jest": {

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -4712,9 +4712,8 @@ react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-"react-native-twilio-video-webrtc@github:blackuy/react-native-twilio-video-webrtc":
+"react-native-twilio-video-webrtc@file:..":
   version "1.0.2-1"
-  resolved "https://codeload.github.com/blackuy/react-native-twilio-video-webrtc/tar.gz/5b8c61048b4448722920b2b0ed9a19e3f64a41ee"
   dependencies:
     prop-types "^15.5.10"
 


### PR DESCRIPTION
This change the import path of the SDK in the example to use the local path instead of the one on github.

I use this path whenever doing any development on the Example as with this change every time your run `yarn install` it uses the local version of the SDK instead of the one on Github.

This makes it much easier for development and generally makes sense for the Example as otherwise PR's would be untestable as the code on Github would not contain the changes that the Example code needs to run.