### PR TITLE
fix onDataTrackMessageReceived type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ declare module "react-native-twilio-video-webrtc" {
     onNetworkQualityLevelsChanged?: NetworkLevelChangeEventCb;
 
     onStatsReceived?: (data: any) => void;
-    onDataTrackMessageReceived?: ({ message: string }) => void;
+    onDataTrackMessageReceived?: (data: { message: string }) => void;
     ref?: React.Ref<any>;
   };
 

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -143,7 +143,7 @@ const propTypes = {
    * Called when dominant speaker changes
    * @param {{ participant, room }} dominant participant and room
    */
-  onDominantSpeakerDidChange: PropTypes.func,
+  onDominantSpeakerDidChange: PropTypes.func
 }
 
 const nativeEvents = {
@@ -165,14 +165,14 @@ const nativeEvents = {
 
 class CustomTwilioVideoView extends Component {
   connect ({
-             roomName,
-             accessToken,
-             enableAudio = true,
-             enableVideo = true,
-             enableRemoteAudio = true,
-             enableNetworkQualityReporting = false,
-             dominantSpeakerEnabled = false
-           }) {
+    roomName,
+    accessToken,
+    enableAudio = true,
+    enableVideo = true,
+    enableRemoteAudio = true,
+    enableNetworkQualityReporting = false,
+    dominantSpeakerEnabled = false
+  }) {
     this.runCommand(nativeEvents.connectToRoom, [
       roomName,
       accessToken,


### PR DESCRIPTION
This PR fixes the following error in `index.d.ts` file
```
node_modules/react-native-twilio-video-webrtc/index.d.ts:93:46 - error TS7031: Binding element 'string' implicitly has an 'any' type.

93     onDataTrackMessageReceived?: ({ message: string }) => void;
                                                ~~~~~~
```                                                
NOTE: Also had to fix standard problems to pass CI tests. Let me know if you'd like it to be in a separate PR