### PR TITLE
Better customisation of call params

### DIFF
--- a/Example/index.js
+++ b/Example/index.js
@@ -35,7 +35,27 @@ const Example = (props) => {
       await _requestAudioPermission();
       await _requestCameraPermission();
     }
-    twilioVideo.current.connect({ accessToken: token, enableNetworkQualityReporting: true});
+    twilioVideo.current.connect({ roomName: "test_room", accessToken: token, 
+        enableAudio: true,
+        enableVideo: true,
+        enableNetworkQualityReporting: false,
+        dominantSpeakerEnabled: false, 
+        encodingParameters: {
+          audioBitrate: 16, // Ideal bitrate for speech
+          videoBitrate: 0, // Use default video bitrate
+        },
+        bandwidthProfileOptions: {
+          mode: "COLLABORATION",
+          maxSubscriptionBitrate: 2500,
+        }
+      })
+
+    // Enabled local camera and specify the resolution and framerate (only applicable for Android)
+    twilioVideo.current.setLocalVideoEnabled(true, {
+      maxDimensions: "640x480",
+      maxFPS: 25
+    })
+
     setStatus("connecting");
   };
 

--- a/Example/package.json
+++ b/Example/package.json
@@ -18,6 +18,9 @@
     "react-native-twilio-video-webrtc": "file:../",
     "react-test-renderer": "16.8.3"
   },
+  "resolutions": {
+    "graceful-fs": "^4.2.4"
+  },
   "jest": {
     "preset": "react-native"
   }

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -25,7 +25,6 @@ import android.os.HandlerThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
-import kotlin.Unit;
 
 import android.util.Log;
 import android.view.View;
@@ -121,7 +120,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     private static final VideoDimensions DEFAULT_MAX_CAPTURE_RESOLUTION = VideoDimensions.CIF_VIDEO_DIMENSIONS;
     private static final int DEFAULT_MAX_CAPTURE_FPS = 25;
 
-    private boolean enableRemoteAudio = false;
     private boolean enableNetworkQualityReporting = false;
     private boolean isVideoEnabled = false;
     private boolean dominantSpeakerEnabled = false;
@@ -421,7 +419,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
             ReadableMap bandwidthProfileOptions) {
         this.roomName = roomName;
         this.accessToken = accessToken;
-        this.enableRemoteAudio = enableAudio;
         this.enableNetworkQualityReporting = enableNetworkQualityReporting;
         this.dominantSpeakerEnabled = dominantSpeakerEnabled;
 
@@ -1163,7 +1160,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         return new RemoteParticipant.Listener() {
             @Override
             public void onAudioTrackSubscribed(RemoteParticipant participant, RemoteAudioTrackPublication publication, RemoteAudioTrack audioTrack) {
-              audioTrack.enablePlayback(enableRemoteAudio);
               WritableMap event = buildParticipantVideoEvent(participant, publication);
               pushEvent(CustomTwilioVideoView.this, ON_PARTICIPANT_ADDED_AUDIO_TRACK, event);
             }

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -22,12 +22,17 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.support.annotation.NonNull;
-import android.support.annotation.StringDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringDef;
+import kotlin.Unit;
+
 import android.util.Log;
 import android.view.View;
 
 import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
@@ -35,9 +40,13 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.twilio.video.AudioTrackPublication;
+import com.twilio.video.BandwidthProfileMode;
+import com.twilio.video.BandwidthProfileOptions;
 import com.twilio.video.BaseTrackStats;
 import com.twilio.video.CameraCapturer;
 import com.twilio.video.ConnectOptions;
+import com.twilio.video.EncodingParameters;
+import com.twilio.video.H264Codec;
 import com.twilio.video.LocalAudioTrack;
 import com.twilio.video.LocalAudioTrackPublication;
 import com.twilio.video.LocalAudioTrackStats;
@@ -66,9 +75,12 @@ import com.twilio.video.Room;
 import com.twilio.video.Room.State;
 import com.twilio.video.StatsListener;
 import com.twilio.video.StatsReport;
+import com.twilio.video.TrackPriority;
 import com.twilio.video.TrackPublication;
+import com.twilio.video.TrackSwitchOffMode;
 import com.twilio.video.TwilioException;
 import com.twilio.video.Video;
+import com.twilio.video.VideoBandwidthProfileOptions;
 import com.twilio.video.VideoConstraints;
 import com.twilio.video.VideoDimensions;
 
@@ -105,10 +117,23 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DOMINANT_SPEA
 public class CustomTwilioVideoView extends View implements LifecycleEventListener, AudioManager.OnAudioFocusChangeListener {
     private static final String TAG = "CustomTwilioVideoView";
     private static final String DATA_TRACK_MESSAGE_THREAD_NAME = "DataTrackMessages";
+
+    private static final VideoDimensions DEFAULT_MAX_CAPTURE_RESOLUTION = VideoDimensions.CIF_VIDEO_DIMENSIONS;
+    private static final int DEFAULT_MAX_CAPTURE_FPS = 25;
+
     private boolean enableRemoteAudio = false;
     private boolean enableNetworkQualityReporting = false;
     private boolean isVideoEnabled = false;
     private boolean dominantSpeakerEnabled = false;
+    private boolean enableH264Codec = false;
+
+    private int audioBitrate = -1;
+    private int videoBitrate = -1;
+
+    private BandwidthProfileOptions bandwidthProfile;
+
+    private VideoDimensions maxCaptureDimensions = CustomTwilioVideoView.DEFAULT_MAX_CAPTURE_RESOLUTION;
+    private int maxCaptureFPS  = CustomTwilioVideoView.DEFAULT_MAX_CAPTURE_FPS;
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({Events.ON_CAMERA_SWITCHED,
@@ -234,11 +259,12 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     // ===== SETUP =================================================================================
 
     private VideoConstraints buildVideoConstraints() {
+        Log.d(TAG,"Setting camera constraints. Max Dimensions: "
+            + this.maxCaptureDimensions + " - Max FPS: " + this.maxCaptureFPS);
+
         return new VideoConstraints.Builder()
-                .minVideoDimensions(VideoDimensions.CIF_VIDEO_DIMENSIONS)
-                .maxVideoDimensions(VideoDimensions.CIF_VIDEO_DIMENSIONS)
-                .minFps(5)
-                .maxFps(15)
+                .maxVideoDimensions(this.maxCaptureDimensions)
+                .maxFps(this.maxCaptureFPS)
                 .build();
     }
 
@@ -391,24 +417,187 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
 
     public void connectToRoomWrapper(
             String roomName, String accessToken, boolean enableAudio, boolean enableVideo,
-            boolean enableRemoteAudio, boolean enableNetworkQualityReporting, boolean dominantSpeakerEnabled) {
+            ReadableMap encodingParameters, boolean enableNetworkQualityReporting, boolean dominantSpeakerEnabled,
+            ReadableMap bandwidthProfileOptions) {
         this.roomName = roomName;
         this.accessToken = accessToken;
         this.enableRemoteAudio = enableAudio;
         this.enableNetworkQualityReporting = enableNetworkQualityReporting;
         this.dominantSpeakerEnabled = dominantSpeakerEnabled;
 
+        if (encodingParameters.hasKey("enableH264Codec")) {
+            this.enableH264Codec = encodingParameters.getBoolean("enableH264Codec");
+        }
+
+        if (encodingParameters.hasKey("audioBitrate")) {
+            this.audioBitrate = encodingParameters.getInt("audioBitrate");
+        }
+
+        if (encodingParameters.hasKey("videoBitrate")) {
+            this.videoBitrate = encodingParameters.getInt("videoBitrate");
+        }
+
+        this.bandwidthProfile = prepareBandwidthProfile(bandwidthProfileOptions);
+
         // Share your microphone
         localAudioTrack = LocalAudioTrack.create(getContext(), enableAudio);
 
         if (cameraCapturer == null) {
-            boolean createVideoStatus = createLocalVideo(enableVideo);
-            if (!createVideoStatus) {
-                // No need to connect to room if video creation failed
-                return;
+                boolean createVideoStatus = createLocalVideo(enableVideo);
+                if (!createVideoStatus) {
+                    // No need to connect to room if video creation failed
+                    return;
+            }
         }
-    }
+
         connectToRoom(enableAudio);
+    }
+
+    // Functions to parse the bandwidth profile map
+    private TrackPriority parsePriorityString(@Nullable String priority) {
+        if (priority != null && !priority.trim().isEmpty()) {
+            if (priority.toUpperCase().equals("LOW")) {
+                return TrackPriority.LOW;
+            } else if (priority.toUpperCase().equals("STANDARD")) {
+                return TrackPriority.STANDARD;
+            } else if (priority.toUpperCase().equals("HIGH")) {
+                return TrackPriority.HIGH;
+            } else if (priority.toUpperCase().equals("NULL")) {
+                return null;
+            } else {
+                Log.w(TAG, "Unknown priority string" + priority);
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private VideoDimensions parseDimensionsString(@Nullable String dimensions) {
+        if (dimensions != null && !dimensions.trim().isEmpty()) {
+            String[] dimensions_array = dimensions.split("x");
+
+            // There can only be 2 items for a correct <width>x<height> string
+            if (dimensions_array.length != 2) {
+                return null;
+            }
+
+            int w = Integer.parseInt(dimensions_array[0]);
+            int h = Integer.parseInt(dimensions_array[1]);
+
+            return new VideoDimensions(w,h);
+        }
+
+        return null;
+    }
+
+    private BandwidthProfileOptions prepareBandwidthProfile(ReadableMap options) {
+
+        BandwidthProfileMode mode = null;
+        TrackSwitchOffMode trackSwitchOffMode = null;
+        @Nullable Long maxTracks = null;
+        @Nullable Long maxSubscriptionBitrate = null;
+        TrackPriority dominantSpeakerPriority = null;
+        Map<TrackPriority, VideoDimensions> renderDimensions = new HashMap<>();
+
+        if (options.hasKey("mode")) {
+            String modeString = options.getString("mode");
+
+            // Parse mode of the current call
+            if (modeString != null) {
+                if (modeString.toUpperCase().equals("GRID")) {
+                    mode = BandwidthProfileMode.GRID;
+                } else if (modeString.toUpperCase().equals("COLLABORATION")) {
+                    mode = BandwidthProfileMode.COLLABORATION;
+                } else if (modeString.toUpperCase().equals("PRESENTATION")) {
+                    mode = BandwidthProfileMode.PRESENTATION;
+                } else {
+                    Log.w(TAG, "Unknown Bandwidth Profile Mode" + modeString);
+                }
+            }
+        }
+
+        if (options.hasKey("trackSwitchOffMode")) {
+            String trackSwitchOffModeString = options.getString("trackSwitchOffMode");
+
+            // Parse mode of the current call
+            if (trackSwitchOffModeString != null) {
+                if (trackSwitchOffModeString.toUpperCase().equals("DISABLED")) {
+                    trackSwitchOffMode = TrackSwitchOffMode.DISABLED;
+                } else if (trackSwitchOffModeString.toUpperCase().equals("PREDICTED")) {
+                    trackSwitchOffMode = TrackSwitchOffMode.PREDICTED;
+                } else if (trackSwitchOffModeString.toUpperCase().equals("DETECTED")) {
+                    trackSwitchOffMode = TrackSwitchOffMode.DETECTED;
+                } else {
+                    Log.w(TAG, "Unknown Track Switch Off Mode" + trackSwitchOffModeString);
+                }
+            }
+        }
+
+        // Parse max tracks to enabled during a call
+        if (options.hasKey("maxTracks")) {
+            int maxTracksAsInt = options.getInt("maxTracks");
+            if (maxTracksAsInt > 0) {
+                maxTracks = (long) maxTracksAsInt;
+            }
+        }
+
+        // Parse max subscription bit rate
+        if (options.hasKey("maxSubscriptionBitrate")) {
+            int maxSubscriptionBitrateAsInt = options.getInt("maxSubscriptionBitrate");
+            if (maxSubscriptionBitrateAsInt > 0) {
+                maxSubscriptionBitrate = (long) maxSubscriptionBitrateAsInt;
+            }
+        }
+
+        // Parse priority for dominant speaker
+        if (options.hasKey("dominantSpeakerPriority")) {
+            dominantSpeakerPriority = parsePriorityString(options.getString("dominantSpeakerPriority"));
+        }
+
+        // Parse Render Dimensions
+        if (options.hasKey("renderDimensions")) {
+            ReadableMap renderDimensionsMap = options.getMap("renderDimensions");
+            if (renderDimensionsMap != null) {
+                if (renderDimensionsMap.hasKey("low")) {
+                    VideoDimensions dimensions = parseDimensionsString(renderDimensionsMap.getString("low"));
+                    if (dimensions != null) {
+                        renderDimensions.put(TrackPriority.LOW, dimensions);
+                    }
+                }
+
+                if (renderDimensionsMap.hasKey("standard")) {
+                    VideoDimensions dimensions = parseDimensionsString(renderDimensionsMap.getString("standard"));
+                    if (dimensions != null) {
+                        renderDimensions.put(TrackPriority.STANDARD, dimensions);
+                    }
+                }
+
+                if (renderDimensionsMap.hasKey("high")) {
+                    VideoDimensions dimensions = parseDimensionsString(renderDimensionsMap.getString("high"));
+                    if (dimensions != null) {
+                        renderDimensions.put(TrackPriority.HIGH, dimensions);
+                    }
+                }
+            }
+        }
+
+        Log.d(TAG, "BandwidthProfile - mode: " + mode);
+        Log.d(TAG, "BandwidthProfile - maxTracks: " + maxTracks);
+        Log.d(TAG, "BandwidthProfile - dominantSpeakerPriority: " + dominantSpeakerPriority);
+        Log.d(TAG, "BandwidthProfile - renderDimensions: " + renderDimensions);
+        Log.d(TAG, "BandwidthProfile - trackSwitchOffMode: " + trackSwitchOffMode);
+
+        VideoBandwidthProfileOptions videoBandwidthProfileOptions = new VideoBandwidthProfileOptions.Builder()
+                .mode(mode)
+                .maxTracks(maxTracks)
+                .dominantSpeakerPriority(dominantSpeakerPriority)
+                .maxSubscriptionBitrate(maxSubscriptionBitrate)
+                .renderDimensions(renderDimensions)
+                .trackSwitchOffMode(trackSwitchOffMode)
+                .build();
+
+        return new BandwidthProfileOptions(videoBandwidthProfileOptions);
     }
 
     public void connectToRoom(boolean enableAudio) {
@@ -444,6 +633,25 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
                      NetworkQualityVerbosity.NETWORK_QUALITY_VERBOSITY_MINIMAL,
                      NetworkQualityVerbosity.NETWORK_QUALITY_VERBOSITY_MINIMAL));
          }
+
+         // If we have specified bit rates then use them
+        if (this.audioBitrate >= 0 && this.videoBitrate >= 0) {
+            connectOptionsBuilder.encodingParameters(new EncodingParameters(this.audioBitrate, this.videoBitrate));
+            Log.d(TAG, "Setting max audio rate" + String.valueOf(this.audioBitrate) + " and max video rate: " + String.valueOf(this.videoBitrate));
+        } else {
+            // If we have specified only 1 of the bit rate values
+            if (this.audioBitrate >= 0 || this.videoBitrate >= 0) {
+                // Then warn the user that we are ignoring the value
+                Log.w(TAG, "Ignoring audio or video bitrate as only 1 of them is defined. Audio: " + String.valueOf(this.audioBitrate) + " Video:" + String.valueOf(this.videoBitrate));
+            }
+        }
+
+         if (this.enableH264Codec) {
+             connectOptionsBuilder.preferVideoCodecs(Collections.singletonList(new H264Codec()));
+             Log.d(TAG, "Preferring H264 Codec");
+         }
+
+        connectOptionsBuilder.bandwidthProfile(this.bandwidthProfile);
 
         room = Video.connect(getContext(), connectOptionsBuilder.build(), roomListener());
     }
@@ -565,8 +773,35 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         }
     }
 
-    public void toggleVideo(boolean enabled) {
-      isVideoEnabled = enabled;
+    public void toggleVideo(boolean enabled, ReadableMap cameraSettings) {
+
+        if (cameraSettings != null) {
+            if (cameraSettings.hasKey("maxDimensions")) {
+                this.maxCaptureDimensions = parseDimensionsString(cameraSettings.getString("maxDimensions"));
+            }
+
+            if (cameraSettings.hasKey("maxFPS")) {
+                this.maxCaptureFPS = cameraSettings.getInt("maxFPS");
+            }
+        }
+
+        if (this.maxCaptureDimensions == null) {
+            this.maxCaptureDimensions = CustomTwilioVideoView.DEFAULT_MAX_CAPTURE_RESOLUTION;
+        }
+
+        if (this.maxCaptureFPS < 1) {
+            this.maxCaptureFPS = CustomTwilioVideoView.DEFAULT_MAX_CAPTURE_FPS;;
+        }
+
+        if (enabled && localVideoTrack == null) {
+            createLocalVideo(enabled);
+            if (localParticipant != null) {
+                localParticipant.publishTrack(localVideoTrack);
+            }
+        }
+        
+        isVideoEnabled = enabled;
+
         if (localVideoTrack != null) {
             localVideoTrack.enable(enabled);
 
@@ -611,6 +846,22 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
                     if(at.getAudioTrack() != null) {
                         ((RemoteAudioTrack)at.getAudioTrack()).enablePlayback(enabled);
                     }
+                }
+            }
+        }
+    }
+
+    public void setTrackPriority(String trackSid, String trackPriorityString) {
+        TrackPriority priority = this.parsePriorityString(trackPriorityString);
+
+        for (RemoteParticipant participant : room.getRemoteParticipants()) {
+            for (RemoteVideoTrackPublication publication : participant.getRemoteVideoTracks()) {
+                RemoteVideoTrack track = publication.getRemoteVideoTrack();
+                if (track == null) {
+                    continue;
+                }
+                if (publication.getTrackSid().equals(trackSid)) {
+                    track.setPriority(priority);
                 }
             }
         }

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -11,6 +11,7 @@ package com.twiliorn.library;
 import android.support.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -59,6 +60,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     private static final int SEND_STRING = 12;
     private static final int PUBLISH_VIDEO = 13;
     private static final int PUBLISH_AUDIO = 14;
+    private static final int SET_TRACK_PRIORITY = 15;
 
     @Override
     public String getName() {
@@ -78,10 +80,14 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 String accessToken = args.getString(1);
                 boolean enableAudio = args.getBoolean(2);
                 boolean enableVideo = args.getBoolean(3);
-                boolean enableRemoteAudio = args.getBoolean(4);
+                ReadableMap encodingParameters = args.getMap(4);
                 boolean enableNetworkQualityReporting = args.getBoolean(5);
                 boolean dominantSpeakerEnabled = args.getBoolean(6);
-                view.connectToRoomWrapper(roomName, accessToken, enableAudio, enableVideo, enableRemoteAudio, enableNetworkQualityReporting, dominantSpeakerEnabled);
+                ReadableMap bandwidthProfileOptions = args.getMap(7);
+                view.connectToRoomWrapper(roomName, accessToken
+                    , enableAudio, enableVideo, encodingParameters
+                    , enableNetworkQualityReporting, dominantSpeakerEnabled
+                    , bandwidthProfileOptions);
                 break;
             case DISCONNECT:
                 view.disconnect();
@@ -91,7 +97,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 break;
             case TOGGLE_VIDEO:
                 Boolean videoEnabled = args.getBoolean(0);
-                view.toggleVideo(videoEnabled);
+                ReadableMap cameraSettings = args.getMap(1);
+                view.toggleVideo(videoEnabled, cameraSettings);
                 break;
             case TOGGLE_SOUND:
                 Boolean audioEnabled = args.getBoolean(0);
@@ -126,6 +133,11 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 break;
             case PUBLISH_AUDIO:
                 view.publishLocalAudio(args.getBoolean(0));
+                break;
+            case SET_TRACK_PRIORITY:
+                String trackSid = args.getString(0);
+                String trackPriorityString = args.getString(1);
+                view.setTrackPriority(trackSid, trackPriorityString);
                 break;
         }
     }
@@ -184,6 +196,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 .put("toggleRemoteSound", TOGGLE_REMOTE_SOUND)
                 .put("toggleBluetoothHeadset", TOGGLE_BLUETOOTH_HEADSET)
                 .put("sendString", SEND_STRING)
+                .put("setTrackPriority", SET_TRACK_PRIORITY)
                 .build();
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,6 +94,40 @@ declare module "react-native-twilio-video-webrtc" {
     ref?: React.Ref<any>;
   };
 
+  export enum bandwidthProfileMode {
+    GRID = "GRID",
+    COLLABORATION = "COLLABORATION",
+    PRESENTATION = "PRESENTATION"
+  }
+
+  export enum priority {
+    LOW = "LOW",
+    STANDARD = "STANDARD",
+    HIGH = "HIGH"
+  }
+
+  export enum trackSwitchOffMode {
+    DISABLED = "DISABLED",
+    PREDICTED = "PREDICTED",
+    DETECTED = "DETECTED"
+  }
+
+  // Dimensions are provided in the string in the format of <width>x<height>
+  export type renderDimensions = {
+    "low"?: string,
+    "standard"?: string
+    "high"?: string
+  }
+
+  export type bandwidthProfileOptions = {
+    mode?: bandwidthProfileMode
+    maxTracks?: number,
+    maxSubscriptionBitrate?: number,
+    dominantSpeakerPriority?: priority,
+    renderDimensions?: renderDimensions,
+    trackSwitchOffMode?:trackSwitchOffMode
+  }
+
   type iOSConnectParams = {
     accessToken: string;
     roomName?: string;
@@ -106,19 +140,29 @@ declare module "react-native-twilio-video-webrtc" {
       videoBitrate?: number;
     };
     enableNetworkQualityReporting?: boolean;
+    dominantSpeakerEnabled?: boolean;
+    bandwidthProfileOptions?: bandwidthProfileOptions;
   };
 
+
   type androidConnectParams = {
-    roomName?: string;
     accessToken: string;
+    roomName?: string;
     enableAudio?: boolean;
     enableVideo?: boolean;
-    enableRemoteAudio?: boolean;
+    encodingParameters?: {
+      enableH264Codec?: boolean;
+      // if audioBitrate OR videoBitrate is provided, you must provide both
+      audioBitrate?: number;
+      videoBitrate?: number;
+    };
     enableNetworkQualityReporting?: boolean;
+    dominantSpeakerEnabled?: boolean;
+    bandwidthProfileOptions?: bandwidthProfileOptions;
   };
 
   class TwilioVideo extends React.Component<TwilioVideoProps> {
-    setLocalVideoEnabled: (enabled: boolean) => Promise<boolean>;
+    setLocalVideoEnabled: (enabled: boolean, cameraSettings?: CameraSettings) => Promise<boolean>;
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setRemoteAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setBluetoothHeadsetConnected: (enabled: boolean) => Promise<boolean>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,58 +94,46 @@ declare module "react-native-twilio-video-webrtc" {
     ref?: React.Ref<any>;
   };
 
-  export enum bandwidthProfileMode {
+  export const  enum BandwidthProfileMode {
     GRID = "GRID",
     COLLABORATION = "COLLABORATION",
-    PRESENTATION = "PRESENTATION"
+    PRESENTATION = "PRESENTATION",
   }
 
-  export enum priority {
+  export const  enum TrackPriorty {
     LOW = "LOW",
     STANDARD = "STANDARD",
-    HIGH = "HIGH"
+    HIGH = "HIGH",
   }
 
-  export enum trackSwitchOffMode {
+  export const enum TrackSwitchOffMode {
     DISABLED = "DISABLED",
     PREDICTED = "PREDICTED",
-    DETECTED = "DETECTED"
+    DETECTED = "DETECTED",
   }
 
-  // Dimensions are provided in the string in the format of <width>x<height>
-  export type renderDimensions = {
-    "low"?: string,
-    "standard"?: string
-    "high"?: string
-  }
-
-  export type bandwidthProfileOptions = {
-    mode?: bandwidthProfileMode
-    maxTracks?: number,
-    maxSubscriptionBitrate?: number,
-    dominantSpeakerPriority?: priority,
-    renderDimensions?: renderDimensions,
-    trackSwitchOffMode?:trackSwitchOffMode
-  }
-
-  type iOSConnectParams = {
-    accessToken: string;
-    roomName?: string;
-    enableAudio?: boolean;
-    enableVideo?: boolean;
-    encodingParameters?: {
-      enableH264Codec?: boolean;
-      // if audioBitrate OR videoBitrate is provided, you must provide both
-      audioBitrate?: number;
-      videoBitrate?: number;
-    };
-    enableNetworkQualityReporting?: boolean;
-    dominantSpeakerEnabled?: boolean;
-    bandwidthProfileOptions?: bandwidthProfileOptions;
+  export type CameraSettings = {
+    maxDimensions: string;
+    maxFPS: number;
   };
 
+  // Dimensions are provided in the string in the format of <width>x<height>
+  export type RenderDimensions = {
+    "low"?: string,
+    "standard"?: string,
+    "high"?: string,
+  }
 
-  type androidConnectParams = {
+  export type BandwidthProfileOptions = {
+    mode?: BandwidthProfileMode
+    maxTracks?: number,
+    maxSubscriptionBitrate?: number,
+    dominantSpeakerPriority?: TrackPriorty,
+    renderDimensions?: RenderDimensions,
+    trackSwitchOffMode?: TrackSwitchOffMode,
+  }
+
+  type ConnectParams = {
     accessToken: string;
     roomName?: string;
     enableAudio?: boolean;
@@ -158,7 +146,7 @@ declare module "react-native-twilio-video-webrtc" {
     };
     enableNetworkQualityReporting?: boolean;
     dominantSpeakerEnabled?: boolean;
-    bandwidthProfileOptions?: bandwidthProfileOptions;
+    bandwidthProfileOptions?: BandwidthProfileOptions;
   };
 
   class TwilioVideo extends React.Component<TwilioVideoProps> {
@@ -166,7 +154,7 @@ declare module "react-native-twilio-video-webrtc" {
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setRemoteAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setBluetoothHeadsetConnected: (enabled: boolean) => Promise<boolean>;
-    connect: (options: iOSConnectParams | androidConnectParams) => void;
+    connect: (options: ConnectParams) => void;
     disconnect: () => void;
     flipCamera: () => void;
     toggleSoundSetup: (speaker: boolean) => void;
@@ -176,6 +164,8 @@ declare module "react-native-twilio-video-webrtc" {
     publishLocalVideo: () => void;
     unpublishLocalVideo: () => void;
     sendString: (message: string) => void;
+    setTrackPriority: (trackSid: string, trackPriority: TrackPriorty) => void;
+    setStereoEnabled: (enabled: boolean) => Promise<boolean>;
   }
 
   class TwilioVideoLocalView extends React.Component<
@@ -187,4 +177,14 @@ declare module "react-native-twilio-video-webrtc" {
   > {}
 
   export { TwilioVideoLocalView, TwilioVideoParticipantView, TwilioVideo };
+
+  export class TwilioStereoTonePlayer {
+      preload: (filename: string) => Promise<boolean>;
+      play: (filename: string, isLooping: boolean, volume: number, playbackSpeed: number) => Promise<void>;
+      pause: () => void;
+      setVolume: (volume: number) => void;
+      setPlaybackSpeed: (speed: number) => void;
+      release: (filename: string) => void;
+      terminate: () => void;
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,23 +94,11 @@ declare module "react-native-twilio-video-webrtc" {
     ref?: React.Ref<any>;
   };
 
-  export const  enum BandwidthProfileMode {
-    GRID = "GRID",
-    COLLABORATION = "COLLABORATION",
-    PRESENTATION = "PRESENTATION",
-  }
+  export type BandwidthProfileMode = "GRID" | "COLLABORATION" | "PRESENTATION";
 
-  export const  enum TrackPriority {
-    LOW = "LOW",
-    STANDARD = "STANDARD",
-    HIGH = "HIGH",
-  }
+  export type TrackPriority = "LOW" | "STANDARD" | "HIGH";
 
-  export const enum TrackSwitchOffMode {
-    DISABLED = "DISABLED",
-    PREDICTED = "PREDICTED",
-    DETECTED = "DETECTED",
-  }
+  export type TrackSwitchOffMode = "DISABLED" | "PREDICTED" | "DETECTED";
 
   export type CameraSettings = {
     maxDimensions: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ declare module "react-native-twilio-video-webrtc" {
     PRESENTATION = "PRESENTATION",
   }
 
-  export const  enum TrackPriorty {
+  export const  enum TrackPriority {
     LOW = "LOW",
     STANDARD = "STANDARD",
     HIGH = "HIGH",
@@ -128,7 +128,7 @@ declare module "react-native-twilio-video-webrtc" {
     mode?: BandwidthProfileMode
     maxTracks?: number,
     maxSubscriptionBitrate?: number,
-    dominantSpeakerPriority?: TrackPriorty,
+    dominantSpeakerPriority?: TrackPriority,
     renderDimensions?: RenderDimensions,
     trackSwitchOffMode?: TrackSwitchOffMode,
   }
@@ -164,7 +164,7 @@ declare module "react-native-twilio-video-webrtc" {
     publishLocalVideo: () => void;
     unpublishLocalVideo: () => void;
     sendString: (message: string) => void;
-    setTrackPriority: (trackSid: string, trackPriority: TrackPriorty) => void;
+    setTrackPriority: (trackSid: string, trackPriority: TrackPriority) => void;
     setStereoEnabled: (enabled: boolean) => Promise<boolean>;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,6 @@ declare module "react-native-twilio-video-webrtc" {
     unpublishLocalVideo: () => void;
     sendString: (message: string) => void;
     setTrackPriority: (trackSid: string, trackPriority: TrackPriority) => void;
-    setStereoEnabled: (enabled: boolean) => Promise<boolean>;
   }
 
   class TwilioVideoLocalView extends React.Component<

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,7 +96,7 @@ declare module "react-native-twilio-video-webrtc" {
 
   export type BandwidthProfileMode = "GRID" | "COLLABORATION" | "PRESENTATION";
 
-  export type TrackPriority = "LOW" | "STANDARD" | "HIGH";
+  export type TrackPriority = "LOW" | "STANDARD" | "HIGH" | "NULL";
 
   export type TrackSwitchOffMode = "DISABLED" | "PREDICTED" | "DETECTED";
 

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -36,11 +36,8 @@ static NSString* cameraDidStopRunning         = @"cameraDidStopRunning";
 static NSString* statsReceived                = @"statsReceived";
 static NSString* networkQualityLevelsChanged  = @"networkQualityLevelsChanged";
 
-static const CMVideoDimensions kRCTTWVideoAppCameraSourceDimensions = (CMVideoDimensions){900, 720};
 
-static const int32_t kRCTTWVideoCameraSourceFrameRate = 15;
-
-TVIVideoFormat *RCTTWVideoModuleCameraSourceSelectVideoFormatBySize(AVCaptureDevice *device, CMVideoDimensions targetSize) {
+TVIVideoFormat *RCTTWVideoModuleCameraSourceSelectVideoFormatBySize(AVCaptureDevice *device, CMVideoDimensions targetSize, NSUInteger targetFps) {
     TVIVideoFormat *selectedFormat = nil;
     // Ordered from smallest to largest.
     NSOrderedSet<TVIVideoFormat *> *formats = [TVICameraSource supportedFormatsForDevice:device];
@@ -49,11 +46,14 @@ TVIVideoFormat *RCTTWVideoModuleCameraSourceSelectVideoFormatBySize(AVCaptureDev
         if (format.pixelFormat != TVIPixelFormatYUV420BiPlanarFullRange) {
             continue;
         }
+        
         selectedFormat = format;
-        // ^ Select whatever is available until we find one we like and short-circuit
+        
+        // ^ Select whatever is available until we find one we like and break the loop
         CMVideoDimensions dimensions = format.dimensions;
+        NSUInteger fps = format.frameRate;
 
-        if (dimensions.width >= targetSize.width && dimensions.height >= targetSize.height) {
+        if (dimensions.width >= targetSize.width && dimensions.height >= targetSize.height && fps >= targetFps) {
             break;
         }
     }
@@ -81,6 +81,7 @@ RCT_EXPORT_MODULE();
 
 - (void)dealloc {
   [self clearCameraInstance];
+  [self stopLocalAudio];
 }
 
 - (dispatch_queue_t)methodQueue {
@@ -290,6 +291,19 @@ RCT_EXPORT_METHOD(toggleSoundSetup:(BOOL)speaker) {
   }
 }
 
+RCT_EXPORT_METHOD(setTrackPriority:(NSString *)trackSid trackPriority:(NSString *)trackPriority) {
+    for (TVIRemoteParticipant *participant in [self.room remoteParticipants]) {
+        if (participant) {
+            for (TVIRemoteVideoTrackPublication *publication in participant.remoteVideoTracks) {
+              if ([publication.trackSid isEqualToString:trackSid]) {
+                  TVITrackPriority priority = [self parsePriorityString:trackPriority];
+                  [publication.remoteTrack setPriority:priority];
+              }
+            }
+        }
+    }
+}
+
 -(void)convertBaseTrackStats:(TVIBaseTrackStats *)stats result:(NSMutableDictionary *)result {
   result[@"trackSid"] = stats.trackSid;
   result[@"packetsLost"] = @(stats.packetsLost);
@@ -388,6 +402,133 @@ RCT_EXPORT_METHOD(getStats) {
 RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled) {
   [self _setLocalVideoEnabled:enableVideo];
 
+-(TVITrackPriority)parsePriorityString:(NSString *)priority {
+    if (priority == nil) {
+        return nil;
+    }
+    
+    if ([[priority uppercaseString] isEqualToString:@"LOW"]) {
+        return TVITrackPriorityLow;
+    } else if ([[priority uppercaseString] isEqualToString:@"STANDARD"]) {
+        return TVITrackPriorityStandard;
+    } else if ([[priority uppercaseString] isEqualToString:@"HIGH"]) {
+        return TVITrackPriorityHigh;
+    } else if ([[priority uppercaseString] isEqualToString:@"NULL"]) {
+        return nil;
+    }
+    return nil;
+}
+
+-(TVIVideoDimensions*)parseDimensionString:(NSString *)dimension {
+    if (dimension == nil) {
+        return nil;
+    }
+    
+    NSArray* dimensionArray = [dimension componentsSeparatedByString:@"x"];
+    if ([dimensionArray count] != 2) {
+        NSLog(@"Malformed dimension. Ignoring: %@", dimension);
+        return nil;
+    }
+    
+    unsigned int width = [[dimensionArray objectAtIndex:0] unsignedIntValue];
+    unsigned int height = [[dimensionArray objectAtIndex:1] unsignedIntValue];
+    
+    return [TVIVideoDimensions dimensionsWithWidth:width height:height];
+}
+
+-(TVIVideoBandwidthProfileOptions*)prepareBandwidthProfile:(NSDictionary *)bandwidthProfileOptions {
+    return [TVIVideoBandwidthProfileOptions optionsWithBlock:^(TVIVideoBandwidthProfileOptionsBuilder * _Nonnull builder) {
+    
+        if (bandwidthProfileOptions[@"mode"]) {
+            TVIBandwidthProfileMode mode;
+            
+            NSString *comparisonString = [(NSString *)[bandwidthProfileOptions objectForKey:@"mode"] uppercaseString];
+            
+            if ([comparisonString isEqualToString:@"GRID"]) {
+                mode = TVIBandwidthProfileModeGrid;
+            } else if ([comparisonString isEqualToString:@"COLLABORATION"]) {
+                mode = TVIBandwidthProfileModeCollaboration;
+            } else if ([comparisonString isEqualToString:@"PRESENTATION"]) {
+                mode = TVIBandwidthProfileModePresentation;
+            }
+            
+            NSLog(@"BandwidthProfile - mode: %@", mode);
+            builder.mode = mode;
+        }
+        
+        if (bandwidthProfileOptions[@"trackSwitchOffMode"]) {
+            TVITrackSwitchOffMode mode;
+            
+            NSString *comparisonString = [(NSString *)[bandwidthProfileOptions objectForKey:@"trackSwitchOffMode"] uppercaseString];
+            
+            if ([comparisonString isEqualToString:@"DISABLED"]) {
+                mode = TVITrackSwitchOffModeDisabled;
+            } else if ([comparisonString isEqualToString:@"PREDICTED"]) {
+                mode = TVITrackSwitchOffModePredicted;
+            } else if ([comparisonString isEqualToString:@"DETECTED"]) {
+                mode = TVITrackSwitchOffModeDetected;
+            }
+            
+            builder.trackSwitchOffMode = mode;
+            NSLog(@"BandwidthProfile - trackSwitchOffMode: %@", mode);
+        }
+        
+        if (bandwidthProfileOptions[@"maxTracks"]) {
+            NSNumber *numberValue = @([bandwidthProfileOptions[@"maxTracks"] integerValue]);
+            
+            if (numberValue > 0) {
+                builder.maxTracks = numberValue;
+                NSLog(@"BandwidthProfile - maxTracks: %@", numberValue);
+            } else {
+                NSLog(@"maxTracks cant be less than 1. Ignoring.");
+            }
+        }
+        
+        if (bandwidthProfileOptions[@"maxSubscriptionBitrate"]) {
+            NSNumber *numberValue = @([bandwidthProfileOptions[@"maxSubscriptionBitrate"] integerValue]);
+            
+            if (numberValue > 0) {
+                builder.maxSubscriptionBitrate = numberValue;
+                NSLog(@"BandwidthProfile - maxSubscriptionBitrate: %@", numberValue);
+            } else {
+                NSLog(@"maxSubscriptionBitrate cant be less than 1. Ignoring.");
+            }
+        }
+        
+        if (bandwidthProfileOptions[@"dominantSpeakerPriority"]) {
+            builder.dominantSpeakerPriority = [self parsePriorityString:(NSString *)[bandwidthProfileOptions objectForKey:@"dominantSpeakerPriority"]];
+            NSLog(@"BandwidthProfile - dominantSpeakerPriority: %@", builder.dominantSpeakerPriority);
+        }
+        
+        if (bandwidthProfileOptions[@"renderDimensions"]) {
+            NSDictionary *renderDimensionsDict = [bandwidthProfileOptions objectForKey:@"renderDimensions"];
+            
+            TVIVideoRenderDimensions *dimensions = [TVIVideoRenderDimensions alloc];
+            
+            if (renderDimensionsDict[@"low"]) {
+                dimensions.low = [self parseDimensionString:(NSString *)[renderDimensionsDict objectForKey:@"low"]];
+                NSLog(@"BandwidthProfile - renderDimensions - low: %lux%lu", (unsigned long)dimensions.low.width, (unsigned long)dimensions.low.height);
+            }
+            
+            if (renderDimensionsDict[@"standard"]) {
+                dimensions.standard = [self parseDimensionString:(NSString *)[renderDimensionsDict objectForKey:@"standard"]];
+                NSLog(@"BandwidthProfile - renderDimensions - standard: %lux%lu", (unsigned long)dimensions.standard.width, (unsigned long)dimensions.standard.height);
+            }
+            
+            if (renderDimensionsDict[@"high"]) {
+                dimensions.high = [self parseDimensionString:(NSString *)[renderDimensionsDict objectForKey:@"high"]];
+                NSLog(@"BandwidthProfile - renderDimensions - high: %lux%lu", (unsigned long)dimensions.high.width, (unsigned long)dimensions.high.height);
+            }
+            
+            builder.renderDimensions = dimensions;
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled bandwidthProfileOptions:(NSDictionary *)bandwidthProfileOptions) {
+  
+  TVIVideoBandwidthProfileOptions* videoBandwidthProfile = [self prepareBandwidthProfile:bandwidthProfileOptions];
+    
   TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithToken:accessToken block:^(TVIConnectOptionsBuilder * _Nonnull builder) {
     if (self.localVideoTrack) {
       builder.videoTracks = @[self.localVideoTrack];
@@ -408,20 +549,37 @@ RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName 
     builder.roomName = roomName;
 
     if(encodingParameters[@"enableH264Codec"]){
-      builder.preferredVideoCodecs = @[ [TVIH264Codec new] ];
+        if ([encodingParameters[@"enableH264Codec"] boolValue] == true) {
+            builder.preferredVideoCodecs = @[ [TVIH264Codec new] ];
+            NSLog(@"Preferring H264 Codec");
+        }
     }
 
-    if(encodingParameters[@"audioBitrate"] || encodingParameters[@"videoBitrate"]){
+    if (encodingParameters[@"audioBitrate"] && encodingParameters[@"videoBitrate"]) {
       NSInteger audioBitrate = [encodingParameters[@"audioBitrate"] integerValue];
       NSInteger videoBitrate = [encodingParameters[@"videoBitrate"] integerValue];
-      builder.encodingParameters = [[TVIEncodingParameters alloc] initWithAudioBitrate:(audioBitrate) ? audioBitrate : 40 videoBitrate:(videoBitrate) ? videoBitrate : 1500];
+        
+        if (audioBitrate >= 0 && videoBitrate >= 0) {
+            builder.encodingParameters = [[TVIEncodingParameters alloc] initWithAudioBitrate:audioBitrate videoBitrate:videoBitrate];
+            NSLog(@"Audio encoding bitrate %li - Video encoding bitrate %li", (long)audioBitrate, (long)videoBitrate);
+        } else {
+            // If we have specified only 1 of the bit rate values
+            if ((audioBitrate >= 0) || (videoBitrate >= 0)) {
+                // Log a warning
+                NSLog(@"Either audio bitrate: %li or video bitrate: %li has an incorrect value. Ignoring both values.", (long)audioBitrate, (long)videoBitrate);
+            }
+        }
+    } else if (encodingParameters[@"audioBitrate"] || encodingParameters[@"videoBitrate"]) {
+        NSLog(@"Either audio or video bit rate is not specified. Ignoring both values");
     }
 
     if (enableNetworkQualityReporting) {
       builder.networkQualityEnabled = true;
       builder.networkQualityConfiguration = [ [TVINetworkQualityConfiguration alloc] initWithLocalVerbosity:TVINetworkQualityVerbosityMinimal remoteVerbosity:TVINetworkQualityVerbosityMinimal];
     }
-
+      
+    builder.bandwidthProfileOptions = [[TVIBandwidthProfileOptions alloc] initWithVideoOptions:videoBandwidthProfile];
+      
   }];
 
   self.room = [TwilioVideoSDK connectWithOptions:connectOptions delegate:self];
@@ -435,6 +593,7 @@ RCT_EXPORT_METHOD(sendString:(nonnull NSString *)message) {
 
 RCT_EXPORT_METHOD(disconnect) {
   [self clearCameraInstance];
+  [self stopLocalAudio];
   [self.room disconnect];
 }
 

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -399,9 +399,6 @@ RCT_EXPORT_METHOD(getStats) {
   }
 }
 
-RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled) {
-  [self _setLocalVideoEnabled:enableVideo];
-
 -(TVITrackPriority)parsePriorityString:(NSString *)priority {
     if (priority == nil) {
         return nil;
@@ -525,16 +522,19 @@ RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName 
     }];
 }
 
-RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled bandwidthProfileOptions:(NSDictionary *)bandwidthProfileOptions) {
-  
-  TVIVideoBandwidthProfileOptions* videoBandwidthProfile = [self prepareBandwidthProfile:bandwidthProfileOptions];
+RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL *)enableAudio enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled bandwidthProfileOptions:(NSDictionary *)bandwidthProfileOptions) {
+
+  [self _setLocalVideoEnabled:enableVideo];
     
+  TVIVideoBandwidthProfileOptions* videoBandwidthProfile = [self prepareBandwidthProfile:bandwidthProfileOptions];
+
   TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithToken:accessToken block:^(TVIConnectOptionsBuilder * _Nonnull builder) {
     if (self.localVideoTrack) {
       builder.videoTracks = @[self.localVideoTrack];
     }
 
     if (self.localAudioTrack) {
+      [self.localAudioTrack setEnabled:enableAudio];
       builder.audioTracks = @[self.localAudioTrack];
     }
 

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -169,18 +169,35 @@ class CustomTwilioVideoView extends Component {
     accessToken,
     enableAudio = true,
     enableVideo = true,
-    enableRemoteAudio = true,
+    encodingParameters = {
+      "enableH264Codec": false,
+      "audioBitrate": -1,
+      "videoBitrate": -1
+    },
     enableNetworkQualityReporting = false,
-    dominantSpeakerEnabled = false
+    dominantSpeakerEnabled = false,
+    bandwidthProfileOptions = {
+      "mode":"",
+      "maxTracks": -1,
+      "maxSubscriptionBitrate": -1,
+      "dominantSpeakerPriority": "",
+      "renderDimensions": {
+        "low": "",
+        "standard": "",
+        "high": "",
+      },
+      "trackSwitchOffMode":"",
+    }
   }) {
     this.runCommand(nativeEvents.connectToRoom, [
       roomName,
       accessToken,
       enableAudio,
       enableVideo,
-      enableRemoteAudio,
+      encodingParameters,
       enableNetworkQualityReporting,
-      dominantSpeakerEnabled
+      dominantSpeakerEnabled,
+      bandwidthProfileOptions
     ])
   }
 
@@ -218,8 +235,8 @@ class CustomTwilioVideoView extends Component {
     this.runCommand(nativeEvents.switchCamera, [])
   }
 
-  setLocalVideoEnabled (enabled) {
-    this.runCommand(nativeEvents.toggleVideo, [enabled])
+  setLocalVideoEnabled (enabled, cameraSettings) {
+    this.runCommand(nativeEvents.toggleVideo, [enabled, cameraSettings])
     return Promise.resolve(enabled)
   }
 
@@ -236,6 +253,10 @@ class CustomTwilioVideoView extends Component {
   setBluetoothHeadsetConnected (enabled) {
     this.runCommand(nativeEvents.toggleBluetoothHeadset, [enabled])
     return Promise.resolve(enabled)
+  }
+  
+  setTrackPriority (trackSid, priority) {
+    this.runCommand(nativeEvents.setTrackPriority, [trackSid, priority])
   }
 
   getStats () {

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -237,14 +237,15 @@ export default class TwilioVideo extends Component {
    * Connect to given room name using the JWT access token
    * @param  {String} roomName    The connecting room name
    * @param  {String} accessToken The Twilio's JWT access token
-   * @param  {boolean} enableVideo Don't start video unless it's necessary
+   * @param  {boolean} enableAudio Enable  audio on call connect
+   * @param  {boolean} enableVideo Enable video on call connect
    * @param  {object} encodingParameters Control Encoding config
    * @param  {Boolean} enableNetworkQualityReporting Report network quality of participants
    * @param  {Boolean} dominantSpeakerEnabled Report network quality of participants
    * @param  {object} bandwidthProfileOptions Report network quality of participants
    */
-  connect ({ roomName, accessToken, enableVideo = true, encodingParameters = null, enableNetworkQualityReporting = false, dominantSpeakerEnabled = false, bandwidthProfileOptions = null }) {
-    TWVideoModule.connect(accessToken, roomName, enableVideo, encodingParameters, enableNetworkQualityReporting, dominantSpeakerEnabled, bandwidthProfileOptions);
+  connect ({ roomName, accessToken, enableAudio = true, enableVideo = true, encodingParameters = null, enableNetworkQualityReporting = false, dominantSpeakerEnabled = false, bandwidthProfileOptions = null }) {
+    TWVideoModule.connect(accessToken, roomName, enableAudio, enableVideo, encodingParameters, enableNetworkQualityReporting, dominantSpeakerEnabled, bandwidthProfileOptions);
   }
 
   /**

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -162,7 +162,7 @@ export default class TwilioVideo extends Component {
 
   componentWillMount () {
     this._registerEvents()
-    this._startLocalVideo()
+    this._startLocalVideo(false)
     this._startLocalAudio()
   }
 
@@ -188,9 +188,11 @@ export default class TwilioVideo extends Component {
   }
 
   /**
-   * Enable or disable local video
+   * Enable or disable local video.
+   * NOTE: cameraSettings are ignored on iOS
    */
-  setLocalVideoEnabled (enabled) {
+  setLocalVideoEnabled (enabled, cameraSettings) {
+    this._startLocalVideo(enabled)
     return TWVideoModule.setLocalVideoEnabled(enabled)
   }
 
@@ -202,7 +204,16 @@ export default class TwilioVideo extends Component {
   }
 
   /**
-   * Filp between the front and back camera
+   * Specifies the priority a remote participants video track should get
+   * @param {*} trackSid the SID of the track setting the priority for
+   * @param {*} trackPriority the priority of the track. Can be low, standard, high or null
+   */
+  setTrackPriority (trackSid, trackPriority) {
+    this.runCommand(nativeEvents.setTrackPriority, [trackSid, trackPriority])
+  }
+
+  /**
+   * Flip between the front and back camera
    */
   flipCamera () {
     TWVideoModule.flipCamera()
@@ -226,11 +237,14 @@ export default class TwilioVideo extends Component {
    * Connect to given room name using the JWT access token
    * @param  {String} roomName    The connecting room name
    * @param  {String} accessToken The Twilio's JWT access token
-   * @param  {String} encodingParameters Control Encoding config
+   * @param  {boolean} enableVideo Don't start video unless it's necessary
+   * @param  {object} encodingParameters Control Encoding config
    * @param  {Boolean} enableNetworkQualityReporting Report network quality of participants
+   * @param  {Boolean} dominantSpeakerEnabled Report network quality of participants
+   * @param  {object} bandwidthProfileOptions Report network quality of participants
    */
-  connect ({ roomName, accessToken, enableVideo = true, encodingParameters = null, enableNetworkQualityReporting = false, dominantSpeakerEnabled = false }) {
-    TWVideoModule.connect(accessToken, roomName, enableVideo, encodingParameters, enableNetworkQualityReporting, dominantSpeakerEnabled)
+  connect ({ roomName, accessToken, enableVideo = true, encodingParameters = null, enableNetworkQualityReporting = false, dominantSpeakerEnabled = false, bandwidthProfileOptions = null }) {
+    TWVideoModule.connect(accessToken, roomName, enableVideo, encodingParameters, enableNetworkQualityReporting, dominantSpeakerEnabled, bandwidthProfileOptions);
   }
 
   /**

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -209,7 +209,7 @@ export default class TwilioVideo extends Component {
    * @param {*} trackPriority the priority of the track. Can be low, standard, high or null
    */
   setTrackPriority (trackSid, trackPriority) {
-    this.runCommand(nativeEvents.setTrackPriority, [trackSid, trackPriority])
+    TWVideoModule.setTrackPriority(trackSid, trackPriority)
   }
 
   /**


### PR DESCRIPTION
This PR adds support for [Bandwidth Profile API](https://www.twilio.com/docs/video/tutorials/using-bandwidth-profile-api), Encoding Parameters and Track Priorities.

The PR allows you to configure all options required for Develop High Quality Video Applications with Twilio: https://www.twilio.com/docs/video/tutorials/developing-high-quality-video-applications

Major changes:
- Support for Bandwidth Profile API
- Support for Track Priority API
- Single interface (i.e same arguments) for calling `Connect` between Android and iOS
- Support for specifying capture resolution on Android
- Cross platform support for specifying encoding parameters (this was only supported on iOS before this PR)

This PR introduces a breaking change from the previous version i.e: it removes support for passing `enableRemoteAudio` on connect for Android.

This functionality was only available on Android and I see there are better ways to implement this feature and the current implementation is already inconsistent as its not supported on iOS.


Outside of this, the overall bandwidth profile API and the new features that I have implemented here are quite well tested into our own product but the implementation in here is not fully tested.

I did a quick test to see if everything was running in this branch due to resolving merge conflicts and I can see everything compiles and runs okay.

It is recommended to test this deeper if possible as I see our own branch and this upstream has some merge conflicts (specially as we have our own implementation of disabling video on connect and this repo has its own implementation of the same logic).