### PR TITLE
fix: adding android variable for not releasing video in onHostPause

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -109,6 +109,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     private boolean enableNetworkQualityReporting = false;
     private boolean isVideoEnabled = false;
     private boolean dominantSpeakerEnabled = false;
+    private boolean maintainVideoTrackInBackground = false;
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({Events.ON_CAMERA_SWITCHED,
@@ -334,7 +335,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
          * Release the local video track before going in the background. This ensures that the
          * camera can be used by other applications while this app is in the background.
          */
-        if (localVideoTrack != null) {
+        if (localVideoTrack != null && !maintainVideoTrackInBackground) {
             /*
              * If this local video track is being shared in a Room, remove from local
              * participant before releasing the video track. Participants will be notified that
@@ -391,12 +392,13 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
 
     public void connectToRoomWrapper(
             String roomName, String accessToken, boolean enableAudio, boolean enableVideo,
-            boolean enableRemoteAudio, boolean enableNetworkQualityReporting, boolean dominantSpeakerEnabled) {
+            boolean enableRemoteAudio, boolean enableNetworkQualityReporting, boolean dominantSpeakerEnabled, boolean maintainVideoTrackInBackground) {
         this.roomName = roomName;
         this.accessToken = accessToken;
         this.enableRemoteAudio = enableAudio;
         this.enableNetworkQualityReporting = enableNetworkQualityReporting;
         this.dominantSpeakerEnabled = dominantSpeakerEnabled;
+        this.maintainVideoTrackInBackground = maintainVideoTrackInBackground;
 
         // Share your microphone
         localAudioTrack = LocalAudioTrack.create(getContext(), enableAudio);

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -81,7 +81,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 boolean enableRemoteAudio = args.getBoolean(4);
                 boolean enableNetworkQualityReporting = args.getBoolean(5);
                 boolean dominantSpeakerEnabled = args.getBoolean(6);
-                view.connectToRoomWrapper(roomName, accessToken, enableAudio, enableVideo, enableRemoteAudio, enableNetworkQualityReporting, dominantSpeakerEnabled);
+                boolean maintainVideoTrackInBackground = args.getBoolean(7);
+                view.connectToRoomWrapper(roomName, accessToken, enableAudio, enableVideo, enableRemoteAudio, enableNetworkQualityReporting, dominantSpeakerEnabled, maintainVideoTrackInBackground);
                 break;
             case DISCONNECT:
                 view.disconnect();

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,7 @@ declare module "react-native-twilio-video-webrtc" {
     enableVideo?: boolean;
     enableRemoteAudio?: boolean;
     enableNetworkQualityReporting?: boolean;
+    maintainVideoTrackInBackground?: boolean;
   };
 
   class TwilioVideo extends React.Component<TwilioVideoProps> {

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -8,141 +8,142 @@
  */
 
 import {
-  requireNativeComponent,
-  View,
   Platform,
   UIManager,
-  findNodeHandle
+  View,
+  findNodeHandle,
+  requireNativeComponent
 } from 'react-native'
 import React, { Component } from 'react'
+
 import PropTypes from 'prop-types'
 
 const propTypes = {
   ...View.propTypes,
   /**
-   * Callback that is called when camera source changes
-   */
+     * Callback that is called when camera source changes
+     */
   onCameraSwitched: PropTypes.func,
 
   /**
-   * Callback that is called when video is toggled.
-   */
+     * Callback that is called when video is toggled.
+     */
   onVideoChanged: PropTypes.func,
 
   /**
-   * Callback that is called when a audio is toggled.
-   */
+     * Callback that is called when a audio is toggled.
+     */
   onAudioChanged: PropTypes.func,
 
   /**
-   * Callback that is called when user is connected to a room.
-   */
+     * Callback that is called when user is connected to a room.
+     */
   onRoomDidConnect: PropTypes.func,
 
   /**
-   * Callback that is called when connecting to room fails.
-   */
+     * Callback that is called when connecting to room fails.
+     */
   onRoomDidFailToConnect: PropTypes.func,
 
   /**
-   * Callback that is called when user is disconnected from room.
-   */
+     * Callback that is called when user is disconnected from room.
+     */
   onRoomDidDisconnect: PropTypes.func,
 
   /**
-   * Called when a new data track has been added
-   *
-   * @param {{participant, track}}
-   */
+     * Called when a new data track has been added
+     *
+     * @param {{participant, track}}
+     */
   onParticipantAddedDataTrack: PropTypes.func,
 
   /**
-   * Called when a data track has been removed
-   *
-   * @param {{participant, track}}
-   */
+     * Called when a data track has been removed
+     *
+     * @param {{participant, track}}
+     */
   onParticipantRemovedDataTrack: PropTypes.func,
 
   /**
-   * Called when an dataTrack receives a message
-   *
-   * @param {{message}}
-   */
+     * Called when an dataTrack receives a message
+     *
+     * @param {{message}}
+     */
   onDataTrackMessageReceived: PropTypes.func,
 
   /**
-   * Called when a new video track has been added
-   *
-   * @param {{participant, track, enabled}}
-   */
+     * Called when a new video track has been added
+     *
+     * @param {{participant, track, enabled}}
+     */
   onParticipantAddedVideoTrack: PropTypes.func,
 
   /**
-   * Called when a video track has been removed
-   *
-   * @param {{participant, track}}
-   */
+     * Called when a video track has been removed
+     *
+     * @param {{participant, track}}
+     */
   onParticipantRemovedVideoTrack: PropTypes.func,
 
   /**
-   * Called when a new audio track has been added
-   *
-   * @param {{participant, track}}
-   */
+     * Called when a new audio track has been added
+     *
+     * @param {{participant, track}}
+     */
   onParticipantAddedAudioTrack: PropTypes.func,
 
   /**
-   * Called when a audio track has been removed
-   *
-   * @param {{participant, track}}
-   */
+     * Called when a audio track has been removed
+     *
+     * @param {{participant, track}}
+     */
   onParticipantRemovedAudioTrack: PropTypes.func,
 
   /**
-   * Callback called a participant enters a room.
-   */
+     * Callback called a participant enters a room.
+     */
   onRoomParticipantDidConnect: PropTypes.func,
 
   /**
-   * Callback that is called when a participant exits a room.
-   */
+     * Callback that is called when a participant exits a room.
+     */
   onRoomParticipantDidDisconnect: PropTypes.func,
   /**
-   * Called when a video track has been enabled.
-   *
-   * @param {{participant, track}}
-   */
+     * Called when a video track has been enabled.
+     *
+     * @param {{participant, track}}
+     */
   onParticipantEnabledVideoTrack: PropTypes.func,
   /**
-   * Called when a video track has been disabled.
-   *
-   * @param {{participant, track}}
-   */
+     * Called when a video track has been disabled.
+     *
+     * @param {{participant, track}}
+     */
   onParticipantDisabledVideoTrack: PropTypes.func,
   /**
-   * Called when an audio track has been enabled.
-   *
-   * @param {{participant, track}}
-   */
+     * Called when an audio track has been enabled.
+     *
+     * @param {{participant, track}}
+     */
   onParticipantEnabledAudioTrack: PropTypes.func,
   /**
-   * Called when an audio track has been disabled.
-   *
-   * @param {{participant, track}}
-   */
+     * Called when an audio track has been disabled.
+     *
+     * @param {{participant, track}}
+     */
   onParticipantDisabledAudioTrack: PropTypes.func,
   /**
-   * Callback that is called when stats are received (after calling getStats)
-   */
+     * Callback that is called when stats are received (after calling getStats)
+     */
   onStatsReceived: PropTypes.func,
   /**
-   * Callback that is called when network quality levels are changed (only if enableNetworkQualityReporting in connect is set to true)
-   */
+     * Callback that is called when network quality levels are changed (only if enableNetworkQualityReporting in connect is set to true)
+     */
   onNetworkQualityLevelsChanged: PropTypes.func,
   /**
-   * Called when dominant speaker changes
-   * @param {{ participant, room }} dominant participant and room
-   */
+     * Called when dominant speaker changes
+     * @param {{ participant, room }} dominant participant and room
+     */
   onDominantSpeakerDidChange: PropTypes.func
 }
 
@@ -171,7 +172,8 @@ class CustomTwilioVideoView extends Component {
     enableVideo = true,
     enableRemoteAudio = true,
     enableNetworkQualityReporting = false,
-    dominantSpeakerEnabled = false
+    dominantSpeakerEnabled = false,
+    maintainVideoTrackInBackground = false
   }) {
     this.runCommand(nativeEvents.connectToRoom, [
       roomName,
@@ -180,7 +182,8 @@ class CustomTwilioVideoView extends Component {
       enableVideo,
       enableRemoteAudio,
       enableNetworkQualityReporting,
-      dominantSpeakerEnabled
+      dominantSpeakerEnabled,
+      maintainVideoTrackInBackground
     ])
   }
 
@@ -300,12 +303,8 @@ class CustomTwilioVideoView extends Component {
   }
 
   render () {
-    return (
-      <NativeCustomTwilioVideoView
-        ref='videoView'
-        {...this.props}
-        {...this.buildNativeEventWrappers()}
-      />
+    return (<NativeCustomTwilioVideoView ref='videoView' {...this.props} {...this.buildNativeEventWrappers()}
+    />
     )
   }
 }


### PR DESCRIPTION
This is a PR that I've been meaning to submit for about a year. Discussed in this issue https://github.com/blackuy/react-native-twilio-video-webrtc/issues/146#issuecomment-626987948

If `maintainVideoTrackInBackground` is set to true, the camera will not be released for usage by other applications while this app is in the background. Releasing the camera causes the video frame to freeze for some devices

