### PR TITLE
Add trackSid to the data track message received event and fix track information on Android

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ onRoomDidFailToConnect | func | no |  | Callback that is called when connecting 
 onRoomDidDisconnect | func | no |  | Callback that is called when user is disconnected from room.
 onParticipantAddedDataTrack | func | no |  | Called when a new data track has been added  @param {{participant, track}}
 onParticipantRemovedDataTrack | func | no |  | Called when a data track has been removed  @param {{participant, track}}
-onDataTrackMessageReceived | func | no |  | Called when an dataTrack receives a message  @param {{message}}
+onDataTrackMessageReceived | func | no |  | Called when an dataTrack receives a message  @param {{message, trackSid}}
 onParticipantAddedVideoTrack | func | no |  | Called when a new video track has been added  @param {{participant, track, enabled}}
 onParticipantRemovedVideoTrack | func | no |  | Called when a video track has been removed  @param {{participant, track}}
 onParticipantAddedAudioTrack | func | no |  | Called when a new audio track has been added  @param {{participant, track}}
@@ -62,7 +62,7 @@ onParticipantEnabledVideoTrack | func | no |  | Called when a video track has be
 onParticipantDisabledVideoTrack | func | no |  | Called when a video track has been disabled.  @param {{participant, track}}
 onParticipantEnabledAudioTrack | func | no |  | Called when an audio track has been enabled.  @param {{participant, track}}
 onParticipantDisabledAudioTrack | func | no |  | Called when an audio track has been disabled.  @param {{participant, track}}
-onDataTrackMessageReceived | func | no |  | Called when an dataTrack receives a message  @param {{message}}
+onDataTrackMessageReceived | func | no |  | Called when an dataTrack receives a message  @param {{message, trackSid}}
 onCameraDidStart | func | no |  | Called when the camera has started
 onCameraWasInterrupted | func | no |  | Called when the camera has been interrupted
 onCameraInterruptionEnded | func | no |  | Called when the camera interruption has ended

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,13 @@ declare module "react-native-twilio-video-webrtc" {
 
   export type TrackEventCb = (t: TrackEventCbArgs) => void;
 
+  export interface DataTrackEventCbArgs {
+    message: string;
+    trackSid: string;
+  }
+
+  export type DataTrackEventCb = (t: DataTrackEventCbArgs) => void;
+
   interface RoomEventCommonArgs {
     roomName: string;
     roomSid: string;
@@ -90,7 +97,7 @@ declare module "react-native-twilio-video-webrtc" {
     onNetworkQualityLevelsChanged?: NetworkLevelChangeEventCb;
 
     onStatsReceived?: (data: any) => void;
-    onDataTrackMessageReceived?: (data: { message: string }) => void;
+    onDataTrackMessageReceived?: DataTrackEventCb;
     ref?: React.Ref<any>;
   };
 

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -597,7 +597,7 @@ RCT_EXPORT_METHOD(disconnect) {
 # pragma mark - TVIRemoteDataTrackDelegate
 
 - (void)remoteDataTrack:(nonnull TVIRemoteDataTrack *)remoteDataTrack didReceiveString:(nonnull NSString *)message {
-    [self sendEventCheckingListenerWithName:dataTrackMessageReceived body:@{ @"message": message }];
+    [self sendEventCheckingListenerWithName:dataTrackMessageReceived body:@{ @"message": message, @"trackSid": remoteDataTrack.sid }];
 }
 
 - (void)remoteDataTrack:(nonnull TVIRemoteDataTrack *)remoteDataTrack didReceiveData:(nonnull NSData *)message {


### PR DESCRIPTION
This PR includes:

- Addition of the trackSid of the remote data track on the onDataTrackMessageReceived event.
- Fix for Android where the track information that was being included in the onParticipantAddedDataTrack and onParticipantRemovedDataTrack events was the same as the information of the participant.