### PR TITLE
Add camera type to the connect options

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -271,13 +271,25 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         }
     }
 
-    private boolean createLocalVideo(boolean enableVideo) {
+    private boolean createLocalVideo(boolean enableVideo, String cameraType) {
       isVideoEnabled = enableVideo;
         // Share your camera
-        cameraCapturer = this.createCameraCaputer(getContext(), CameraCapturer.CameraSource.FRONT_CAMERA);
-        if (cameraCapturer == null){
-            cameraCapturer = this.createCameraCaputer(getContext(), CameraCapturer.CameraSource.BACK_CAMERA);
+        if (cameraType.equals("front")){
+          cameraCapturer = this.createCameraCaputer(getContext(), CameraCapturer.CameraSource.FRONT_CAMERA);
+        } else {
+          cameraCapturer = this.createCameraCaputer(getContext(), CameraCapturer.CameraSource.BACK_CAMERA);
         }
+
+        // IF the camera is unavailable try the other camera
+        if (cameraCapturer == null) {
+          if (cameraType.equals("front")){
+            cameraCapturer = this.createCameraCaputer(getContext(), CameraCapturer.CameraSource.BACK_CAMERA);
+          } else {
+            cameraCapturer = this.createCameraCaputer(getContext(), CameraCapturer.CameraSource.FRONT_CAMERA);
+          }
+        }
+
+        // If no camera is available let the caller know
         if (cameraCapturer == null){
             WritableMap event = new WritableNativeMap();
             event.putString("error", "No camera is supported on this device");
@@ -391,8 +403,16 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     // ====== CONNECTING ===========================================================================
 
     public void connectToRoomWrapper(
-            String roomName, String accessToken, boolean enableAudio, boolean enableVideo,
-            boolean enableRemoteAudio, boolean enableNetworkQualityReporting, boolean dominantSpeakerEnabled, boolean maintainVideoTrackInBackground) {
+            String roomName,
+            String accessToken,
+            boolean enableAudio,
+            boolean enableVideo,
+            boolean enableRemoteAudio,
+            boolean enableNetworkQualityReporting,
+            boolean dominantSpeakerEnabled,
+            boolean maintainVideoTrackInBackground,
+            String cameraType
+          ) {
         this.roomName = roomName;
         this.accessToken = accessToken;
         this.enableRemoteAudio = enableAudio;
@@ -404,7 +424,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         localAudioTrack = LocalAudioTrack.create(getContext(), enableAudio);
 
         if (cameraCapturer == null) {
-            boolean createVideoStatus = createLocalVideo(enableVideo);
+            boolean createVideoStatus = createLocalVideo(enableVideo, cameraType);
             if (!createVideoStatus) {
                 // No need to connect to room if video creation failed
                 return;

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -82,7 +82,18 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 boolean enableNetworkQualityReporting = args.getBoolean(5);
                 boolean dominantSpeakerEnabled = args.getBoolean(6);
                 boolean maintainVideoTrackInBackground = args.getBoolean(7);
-                view.connectToRoomWrapper(roomName, accessToken, enableAudio, enableVideo, enableRemoteAudio, enableNetworkQualityReporting, dominantSpeakerEnabled, maintainVideoTrackInBackground);
+                String cameraType = args.getString(8);
+                view.connectToRoomWrapper(
+                    roomName,
+                    accessToken,
+                    enableAudio,
+                    enableVideo,
+                    enableRemoteAudio,
+                    enableNetworkQualityReporting,
+                    dominantSpeakerEnabled,
+                    maintainVideoTrackInBackground,
+                    cameraType
+                  );
                 break;
             case DISCONNECT:
                 view.disconnect();

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,8 @@ declare module "react-native-twilio-video-webrtc" {
   }
 
   type scaleType = "fit" | "fill";
+  type cameraType = "front" | "back";
+
   interface TwilioVideoParticipantViewProps extends ViewProps {
     trackIdentifier: TrackIdentifier;
     ref?: React.Ref<any>;
@@ -102,8 +104,9 @@ declare module "react-native-twilio-video-webrtc" {
   };
 
   type iOSConnectParams = {
-    accessToken: string;
     roomName?: string;
+    accessToken: string;
+    cameraType?: cameraType;
     enableAudio?: boolean;
     enableVideo?: boolean;
     encodingParameters?: {
@@ -118,6 +121,7 @@ declare module "react-native-twilio-video-webrtc" {
   type androidConnectParams = {
     roomName?: string;
     accessToken: string;
+    cameraType?: cameraType;
     enableAudio?: boolean;
     enableVideo?: boolean;
     enableRemoteAudio?: boolean;

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -175,11 +175,17 @@ RCT_EXPORT_METHOD(startLocalVideo) {
   self.localVideoTrack = [TVILocalVideoTrack trackWithSource:self.camera enabled:NO name:@"camera"];
 }
 
-- (void)startCameraCapture {
+- (void)startCameraCapture:(NSString *)cameraType {
   if (self.camera == nil) {
     return;
   }
-  AVCaptureDevice *camera = [TVICameraSource captureDeviceForPosition:AVCaptureDevicePositionFront];
+  AVCaptureDevice *camera;
+    if ([cameraType isEqualToString:@"back"]) {
+    camera = [TVICameraSource captureDeviceForPosition:AVCaptureDevicePositionBack];
+  } else {
+    camera = [TVICameraSource captureDeviceForPosition:AVCaptureDevicePositionFront];
+  }
+
   [self.camera startCaptureWithDevice:camera completion:^(AVCaptureDevice *device,
           TVIVideoFormat *startFormat,
           NSError *error) {
@@ -235,12 +241,18 @@ RCT_REMAP_METHOD(setLocalAudioEnabled, enabled:(BOOL)enabled setLocalAudioEnable
   resolve(@(enabled));
 }
 
+
+// set a default for setting local video enabled
 - (bool)_setLocalVideoEnabled:(bool)enabled {
+    return [self _setLocalVideoEnabled:enabled cameraType:@"front"];
+}
+
+- (bool)_setLocalVideoEnabled:(bool)enabled cameraType:(NSString *)cameraType {
   if (self.localVideoTrack != nil) {
       [self.localVideoTrack setEnabled:enabled];
       if (self.camera) {
           if (enabled) {
-            [self startCameraCapture];
+            [self startCameraCapture:cameraType];
           } else {
             [self clearCameraInstance];
           }
@@ -385,8 +397,8 @@ RCT_EXPORT_METHOD(getStats) {
   }
 }
 
-RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled) {
-  [self _setLocalVideoEnabled:enableVideo];
+RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled cameraType:(NSString *)cameraType) {
+   [self _setLocalVideoEnabled:enableVideo cameraType:cameraType];
 
   TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithToken:accessToken block:^(TVIConnectOptionsBuilder * _Nonnull builder) {
     if (self.localVideoTrack) {
@@ -612,3 +624,4 @@ RCT_EXPORT_METHOD(disconnect) {
 }
 
 @end
+

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -168,6 +168,7 @@ class CustomTwilioVideoView extends Component {
   connect ({
     roomName,
     accessToken,
+    cameraType = "front",
     enableAudio = true,
     enableVideo = true,
     enableRemoteAudio = true,
@@ -183,7 +184,8 @@ class CustomTwilioVideoView extends Component {
       enableRemoteAudio,
       enableNetworkQualityReporting,
       dominantSpeakerEnabled,
-      maintainVideoTrackInBackground
+      maintainVideoTrackInBackground,
+      cameraType
     ])
   }
 

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -229,8 +229,23 @@ export default class TwilioVideo extends Component {
    * @param  {String} encodingParameters Control Encoding config
    * @param  {Boolean} enableNetworkQualityReporting Report network quality of participants
    */
-  connect ({ roomName, accessToken, enableVideo = true, encodingParameters = null, enableNetworkQualityReporting = false, dominantSpeakerEnabled = false }) {
-    TWVideoModule.connect(accessToken, roomName, enableVideo, encodingParameters, enableNetworkQualityReporting, dominantSpeakerEnabled)
+  connect ({
+    roomName,
+    accessToken,
+    cameraType = "front",
+    enableVideo = true,
+    encodingParameters = null,
+    enableNetworkQualityReporting = false,
+    dominantSpeakerEnabled = false
+  }) {
+    TWVideoModule.connect(accessToken,
+      roomName,
+      enableVideo,
+      encodingParameters,
+      enableNetworkQualityReporting,
+      dominantSpeakerEnabled,
+      cameraType,
+    )
   }
 
   /**


### PR DESCRIPTION
This PR adds the `cameraType` option to the connect method, so that it can be used to start the video from either the front or back camera.