### PR TITLE
Add autoInitializeCamera prop

### DIFF
--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -150,6 +150,12 @@ export default class TwilioVideo extends Component {
      * @param {{ participant, room }} dominant participant
      */
     onDominantSpeakerDidChange: PropTypes.func,
+    /**
+     * Whether or not video should be automatically initialized upon mounting
+     * of this component. Defaults to true. If set to false, any use of the
+     * camera will require calling `_startLocalVideo`.
+     */
+    autoInitializeCamera: PropTypes.bool,
     ...View.propTypes
   }
 
@@ -162,7 +168,9 @@ export default class TwilioVideo extends Component {
 
   componentDidMount () {
     this._registerEvents()
-    this._startLocalVideo()
+    if (this.props.autoInitializeCamera !== false) {
+      this._startLocalVideo()
+    }
     this._startLocalAudio()
   }
 


### PR DESCRIPTION
Currently the TwilioVideo will automatically initialize the camera upon mounting.  In certain applications this may not be desired.  This PR adds a new flag so that callers can disable the camera (and the need for any permissions).