### PR TITLE
Add dominant speaker to the TypeScript definition

### DIFF
--- a/Example/index.js
+++ b/Example/index.js
@@ -35,7 +35,7 @@ const Example = (props) => {
       await _requestAudioPermission();
       await _requestCameraPermission();
     }
-    twilioVideo.current.connect({ accessToken: token, enableNetworkQualityReporting: true});
+    twilioVideo.current.connect({ accessToken: token, enableNetworkQualityReporting: true, dominantSpeakerEnabled: true});
     setStatus("connecting");
   };
 
@@ -96,6 +96,9 @@ const Example = (props) => {
     console.log("Participant", participant, "isLocalUser", isLocalUser, "quality", quality);
   };
 
+  const _onDominantSpeakerDidChange = ({ roomName, roomSid, participant }) => {
+    console.log("onDominantSpeakerDidChange", `roomName: ${roomName}`, `roomSid: ${roomSid}`, "participant:", participant);
+  };
 
   const _requestAudioPermission = () => {
     return PermissionsAndroid.request(
@@ -187,6 +190,7 @@ const Example = (props) => {
         onParticipantAddedVideoTrack={_onParticipantAddedVideoTrack}
         onParticipantRemovedVideoTrack={_onParticipantRemovedVideoTrack}
         onNetworkQualityLevelsChanged={_onNetworkLevelChanged}
+        onDominantSpeakerDidChange={_onDominantSpeakerDidChange}
       />
     </View>
   );

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,10 +78,17 @@ declare module "react-native-twilio-video-webrtc" {
   
   export type NetworkLevelChangeEventCb = (p: NetworkLevelChangeEventArgs) => void;
 
+  export type DominantSpeakerChangedEventArgs = RoomEventCommonArgs & {
+    participant: Participant;
+  }
+  
+  export type DominantSpeakerChangedCb = (d: DominantSpeakerChangedEventArgs) => void;
+
   export type TwilioVideoProps = ViewProps & {
     onCameraDidStart?: () => void;
     onCameraDidStopRunning?: (err: any) => void;
     onCameraWasInterrupted?: () => void;
+    onDominantSpeakerDidChange?: DominantSpeakerChangedCb;
     onParticipantAddedAudioTrack?: TrackEventCb;
     onParticipantAddedVideoTrack?: TrackEventCb;
     onParticipantDisabledVideoTrack?: TrackEventCb;
@@ -108,6 +115,7 @@ declare module "react-native-twilio-video-webrtc" {
     roomName?: string;
     accessToken: string;
     cameraType?: cameraType;
+    dominantSpeakerEnabled?: boolean;
     enableAudio?: boolean;
     enableVideo?: boolean;
     encodingParameters?: {
@@ -123,6 +131,7 @@ declare module "react-native-twilio-video-webrtc" {
     roomName?: string;
     accessToken: string;
     cameraType?: cameraType;
+    dominantSpeakerEnabled?: boolean;
     enableAudio?: boolean;
     enableVideo?: boolean;
     enableRemoteAudio?: boolean;

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -168,7 +168,7 @@ class CustomTwilioVideoView extends Component {
   connect ({
     roomName,
     accessToken,
-    cameraType = "front",
+    cameraType = 'front',
     enableAudio = true,
     enableVideo = true,
     enableRemoteAudio = true,

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -240,7 +240,7 @@ export default class TwilioVideo extends Component {
   connect ({
     roomName,
     accessToken,
-    cameraType = "front",
+    cameraType = 'front',
     enableAudio = true,
     enableVideo = true,
     encodingParameters = null,
@@ -254,7 +254,7 @@ export default class TwilioVideo extends Component {
       encodingParameters,
       enableNetworkQualityReporting,
       dominantSpeakerEnabled,
-      cameraType,
+      cameraType
     )
   }
 


### PR DESCRIPTION
TypeScript definition file does not expose the dominant speaker feature. Add the connection param, and callback to enable this feature.
