### PR TITLE
Set audio port override in toggleSpeaker

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -291,13 +291,15 @@ RCT_EXPORT_METHOD(toggleSoundSetup:(BOOL)speaker) {
   NSError *error = nil;
   kTVIDefaultAVAudioSessionConfigurationBlock();
   AVAudioSession *session = [AVAudioSession sharedInstance];
-  AVAudioSessionMode mode = speaker ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat ;
+  AVAudioSessionMode mode = speaker ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
   // Overwrite the audio route
   if (![session setMode:mode error:&error]) {
     NSLog(@"AVAudiosession setMode %@",error);
   }
 
-  if (![session overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error]) {
+  AVAudioSessionPortOverride portOverride = speaker: AVAudioSessionPortOverrideSpeaker : AVAudioSessionPortOverrideNone;
+
+  if (![session overrideOutputAudioPort:portOverride error:&error]) {
     NSLog(@"AVAudiosession overrideOutputAudioPort %@",error);
   }
 }
@@ -417,7 +419,7 @@ RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName 
     if (self.localDataTrack) {
       builder.dataTracks = @[self.localDataTrack];
     }
-      
+
     builder.dominantSpeakerEnabled = dominantSpeakerEnabled ? YES : NO;
 
     builder.roomName = roomName;


### PR DESCRIPTION
Set the audio port override to ensure that when speaker is true that the audio is routed correctly to the speaker on iOS.