### PR TITLE
Adds iOS 9 & 10 build support via Twilio Video 4.6

### DIFF
--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -13,11 +13,11 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/blackuy/react-native-twilio-video-web-rtc', tag: s.version }
 
   s.requires_arc   = true
-  s.platform       = :ios, '11.0'
+  s.platform       = :ios, '10.0'
 
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 4.1'
+  s.dependency 'TwilioVideo', '~> 4.6'
 end


### PR DESCRIPTION
Untested other than it didn't break my app ¯\\_(ツ)_/¯

This PR enables build support for iOS 9 & 10 with an upgrade to Twilio 4.6. iOS 9/10 support actually comes from Twilio Video 4.2, which restores ones ability to build apps for iOS 9 & 10 but the API itself does not actually allow video call usage on iOS 9 & 10. 

See [Twilio's Changelog notes](https://www.twilio.com/docs/video/changelog-twilio-video-ios-latest#420-january-27-2021)

