### PR TITLE
Allow callback for H264 codec not support for Android Devices

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -41,7 +41,7 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_D
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_STATS_RECEIVED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_NETWORK_QUALITY_LEVELS_CHANGED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DOMINANT_SPEAKER_CHANGED;
-import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_LOCAL_PARTICIPANT_H264_SUPPORTED;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS;
 
 public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilioVideoView> {
     public static final String REACT_CLASS = "RNCustomTwilioVideoView";
@@ -171,7 +171,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
 
         map.putAll(MapBuilder.of(
                 ON_PARTICIPANT_REMOVED_DATA_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_DATA_TRACK),
-                ON_LOCAL_PARTICIPANT_H264_SUPPORTED, MapBuilder.of("registrationName", ON_LOCAL_PARTICIPANT_H264_SUPPORTED)
+                ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS, MapBuilder.of("registrationName", ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS)
         ));
 
         map.putAll(MapBuilder.of(

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -11,6 +11,7 @@ package com.twiliorn.library;
 import android.support.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -40,7 +41,7 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_D
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_STATS_RECEIVED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_NETWORK_QUALITY_LEVELS_CHANGED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DOMINANT_SPEAKER_CHANGED;
-
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_LOCAL_PARTICIPANT_H264_SUPPORTED;
 
 public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilioVideoView> {
     public static final String REACT_CLASS = "RNCustomTwilioVideoView";
@@ -83,6 +84,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 boolean dominantSpeakerEnabled = args.getBoolean(6);
                 boolean maintainVideoTrackInBackground = args.getBoolean(7);
                 String cameraType = args.getString(8);
+                ReadableMap encodingParameters = args.getMap(9);
+                boolean enableH264Codec = encodingParameters.getBoolean("enableH264Codec");
                 view.connectToRoomWrapper(
                     roomName,
                     accessToken,
@@ -92,7 +95,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                     enableNetworkQualityReporting,
                     dominantSpeakerEnabled,
                     maintainVideoTrackInBackground,
-                    cameraType
+                    cameraType,
+                    enableH264Codec
                   );
                 break;
             case DISCONNECT:
@@ -166,7 +170,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
         ));
 
         map.putAll(MapBuilder.of(
-                ON_PARTICIPANT_REMOVED_DATA_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_DATA_TRACK)
+                ON_PARTICIPANT_REMOVED_DATA_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_DATA_TRACK),
+                ON_LOCAL_PARTICIPANT_H264_SUPPORTED, MapBuilder.of("registrationName", ON_LOCAL_PARTICIPANT_H264_SUPPORTED)
         ));
 
         map.putAll(MapBuilder.of(

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,8 @@ onCameraDidStopRunning | func | no |  | Called when the camera has stopped runin
 onStatsReceived | func | no |  | Called when stats are received (after calling getStats)
 onNetworkQualityLevelsChanged | func | no |  | Called when the network quality levels of a participant have changed (only if enableNetworkQualityReporting is set to True when connecting)
 onDominantSpeakerDidChange | func | no |  | Called when dominant speaker changes @param {{ participant, room }} dominant participant
+onLocalParticipantH264Supported | func | no |  | Always called on android with @param {{ isH264Enabled }} after connecting to the room
+
 -----
 
 **src/TwilioVideoLocalView.android.js**

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ onCameraDidStopRunning | func | no |  | Called when the camera has stopped runin
 onStatsReceived | func | no |  | Called when stats are received (after calling getStats)
 onNetworkQualityLevelsChanged | func | no |  | Called when the network quality levels of a participant have changed (only if enableNetworkQualityReporting is set to True when connecting)
 onDominantSpeakerDidChange | func | no |  | Called when dominant speaker changes @param {{ participant, room }} dominant participant
-onLocalParticipantH264Supported | func | no |  | Always called on android with @param {{ isH264Enabled }} after connecting to the room
+onLocalParticipantSupportedCodecs | func | no |  | Always called on android with @param {{ supportedCodecs }} after connecting to the room
 
 -----
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,11 +84,11 @@ declare module "react-native-twilio-video-webrtc" {
   
   export type DominantSpeakerChangedCb = (d: DominantSpeakerChangedEventArgs) => void;
 
-  export type LocalParticipantH264CbEventArgs = {
-    isH264Supported: boolean;
+  export type LocalParticipantSupportedCodecsCbEventArgs = {
+    supportedCodecs: Array<string>;
   }
 
-  export type LocalParticipantH264Cb = (d: LocalParticipantH264CbEventArgs) => void;
+  export type LocalParticipantSupportedCodecsCb = (d: LocalParticipantSupportedCodecsCbEventArgs) => void;
 
   export type TwilioVideoProps = ViewProps & {
     onCameraDidStart?: () => void;
@@ -111,7 +111,7 @@ declare module "react-native-twilio-video-webrtc" {
     onRoomParticipantDidConnect?: ParticipantEventCb;
     onRoomParticipantDidDisconnect?: ParticipantEventCb;
     onNetworkQualityLevelsChanged?: NetworkLevelChangeEventCb;
-    onLocalParticipantH264Supported?: LocalParticipantH264Cb;
+    onLocalParticipantSupportedCodecs?: LocalParticipantSupportedCodecsCb;
 
     onStatsReceived?: (data: any) => void;
     onDataTrackMessageReceived?: DataTrackEventCb;

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,12 @@ declare module "react-native-twilio-video-webrtc" {
   
   export type DominantSpeakerChangedCb = (d: DominantSpeakerChangedEventArgs) => void;
 
+  export type LocalParticipantH264CbEventArgs = {
+    isH264Supported: boolean;
+  }
+
+  export type LocalParticipantH264Cb = (d: LocalParticipantH264CbEventArgs) => void;
+
   export type TwilioVideoProps = ViewProps & {
     onCameraDidStart?: () => void;
     onCameraDidStopRunning?: (err: any) => void;
@@ -105,6 +111,7 @@ declare module "react-native-twilio-video-webrtc" {
     onRoomParticipantDidConnect?: ParticipantEventCb;
     onRoomParticipantDidDisconnect?: ParticipantEventCb;
     onNetworkQualityLevelsChanged?: NetworkLevelChangeEventCb;
+    onLocalParticipantH264Supported?: LocalParticipantH264Cb;
 
     onStatsReceived?: (data: any) => void;
     onDataTrackMessageReceived?: DataTrackEventCb;
@@ -137,6 +144,9 @@ declare module "react-native-twilio-video-webrtc" {
     enableAudio?: boolean;
     enableVideo?: boolean;
     enableRemoteAudio?: boolean;
+    encodingParameters?: {
+      enableH264Codec?: boolean;
+    };
     enableNetworkQualityReporting?: boolean;
     maintainVideoTrackInBackground?: boolean;
   };

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -144,7 +144,11 @@ const propTypes = {
      * Called when dominant speaker changes
      * @param {{ participant, room }} dominant participant and room
      */
-  onDominantSpeakerDidChange: PropTypes.func
+  onDominantSpeakerDidChange: PropTypes.func,
+  /**
+     * Callback that is called after determining whether the participant has H264 support
+     */
+  onLocalParticipantH264Supported: PropTypes.func
 }
 
 const nativeEvents = {
@@ -174,7 +178,8 @@ class CustomTwilioVideoView extends Component {
     enableRemoteAudio = true,
     enableNetworkQualityReporting = false,
     dominantSpeakerEnabled = false,
-    maintainVideoTrackInBackground = false
+    maintainVideoTrackInBackground = false,
+    encodingParameters = {}
   }) {
     this.runCommand(nativeEvents.connectToRoom, [
       roomName,
@@ -185,7 +190,8 @@ class CustomTwilioVideoView extends Component {
       enableNetworkQualityReporting,
       dominantSpeakerEnabled,
       maintainVideoTrackInBackground,
-      cameraType
+      cameraType,
+      encodingParameters
     ])
   }
 
@@ -292,7 +298,8 @@ class CustomTwilioVideoView extends Component {
       'onParticipantDisabledAudioTrack',
       'onStatsReceived',
       'onNetworkQualityLevelsChanged',
-      'onDominantSpeakerDidChange'
+      'onDominantSpeakerDidChange',
+      'onLocalParticipantH264Supported'
     ].reduce((wrappedEvents, eventName) => {
       if (this.props[eventName]) {
         return {

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -146,9 +146,9 @@ const propTypes = {
      */
   onDominantSpeakerDidChange: PropTypes.func,
   /**
-     * Callback that is called after determining whether the participant has H264 support
+     * Callback that is called after determining what codecs are supported
      */
-  onLocalParticipantH264Supported: PropTypes.func
+  onLocalParticipantSupportedCodecs: PropTypes.func
 }
 
 const nativeEvents = {
@@ -299,7 +299,7 @@ class CustomTwilioVideoView extends Component {
       'onStatsReceived',
       'onNetworkQualityLevelsChanged',
       'onDominantSpeakerDidChange',
-      'onLocalParticipantH264Supported'
+      'onLocalParticipantSupportedCodecs'
     ].reduce((wrappedEvents, eventName) => {
       if (this.props[eventName]) {
         return {


### PR DESCRIPTION
I was facing the same issue reported here: https://github.com/blackuy/react-native-twilio-video-webrtc/issues/517 on an Android Pixel 6 Pro, a relatively new device. 

The issue stems from that some android devices do not fully support H264 codec, therefore video tracks from other participants could not be subscribed and throws an exception. 
I currently have the codec preference set for all my users to be ['H264', 'VP8'] from the web and other devices in a Small Group setting. Which means H264 will always be the codec negotiated by the Selective Forwarding Unit from Twilio if at least one participant has this preference.

According to Twilio Support, if I want to support Android Devices that do not have H264 support, I should change all the preferences to be ['VP8']. 

I want to continue using H264, but also support VP8, so what I am adding here to the library is a way for my app to know when an unsupported H264 device has been used to connect, and properly handle it by changing the other participants codec to be ['VP8'] instead of ['H264', 'VP8'] and re-connect. This way the video tracks are published using VP8 and can be subscribed to.

Most of the code for H264 detection comes from here: 
https://www.twilio.com/docs/video/managing-codecs
