### PR TITLE
Upgrade TwilioVideo in Android to 7.3.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 39
+def DEFAULT_COMPILE_SDK_VERSION             = 30
 def DEFAULT_BUILD_TOOLS_VERSION             = "27.0.3"
 def DEFAULT_TARGET_SDK_VERSION              = 30
 def DEFAULT_ANDROID_SUPPORT_VERSION         = "27.1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 27
+def DEFAULT_COMPILE_SDK_VERSION             = 39
 def DEFAULT_BUILD_TOOLS_VERSION             = "27.0.3"
-def DEFAULT_TARGET_SDK_VERSION              = 27
+def DEFAULT_TARGET_SDK_VERSION              = 30
 def DEFAULT_ANDROID_SUPPORT_VERSION         = "27.1.0"
-def DEFAULT_ANDROID_MIN_SDK_VERSION         = 16
+def DEFAULT_ANDROID_MIN_SDK_VERSION         = 21
 
 android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -50,7 +50,7 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "com.android.support:appcompat-v7:$androidSupportVersion"
-    implementation "com.twilio:video-android:6.2.1"
-    implementation 'org.webrtc:google-webrtc:1.0.30039'
+    implementation "com.twilio:video-android:7.3.1"
+    implementation 'org.webrtc:google-webrtc:1.0.32006'
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }


### PR DESCRIPTION
> Support for 6.x will cease on September 17th, 2022. This branch will only receive fixes for critical issues until that date.

## Migration Docs
Link: https://www.twilio.com/docs/video/migrating-6x-7x

So far nothing important:
- the inclusion of `frames_encoded` in the returned data is not included in this PR
- I don't think the ordering of `onAudioTrackSubscribed` and `onVideoTrackSubscribed` ever mattered?


## [BREAKING] Changes:
- [BREAKING] Minimum SDK will now be 21 instead of 16
  - Update also bumped Google WebRTC to 1.0.32006 from 1.0.30039


# Tests
Tested `ios -> android` and `web -> android`, was not able to test `android -> android` and multiple participants

### Android
| Device | OS Version | Twilio Version |
| ----------- | ----------- | ----------- |
| Huawei Y7a (PPA-LX2)  | EMUI 10.1.1 Android 10 | 7.3.1 |
| Galaxy A71 (SM-A715F/DS) | One UI 4.1 Android 12 | 7.3.1 |
| Huawei nova 3i (INE-LX2)  | EMUI 9.1.1 Android 9 | 7.3.1 |
| vivo Y85A | Funtouch OS_4.0 Android 8.1.0 | 7.3.1 |

### iOS/iPadOS
| Device | OS Version | Twilio Version |
| ----------- | ----------- | ----------- |
| iPad 8th Gen | 15.6.1 | 4.6.1 |

### Web
| Browser | OS Version | Twilio Version |
| ----------- | ----------- | ----------- |
| Chrome Version 105.0.5195.102 | Windows 11 HSL 21H2 22000.918 | 2.17.1 |
| Safari  | iPadOS 15.16.1 | 2.17.1 |
| Browser 12.1.0.303 | EMUI 10.1.1 Android 10 | 2.17.1 |
| Chrome Version 105.0.5195.79 | One UI 4.1 Android 12 | 2.17.1 |



If anyone can double check, that would be greatly appreciated 