### PR TITLE
Add screen share support on both platforms (Android & IOS)

### DIFF
--- a/Example/index.js
+++ b/Example/index.js
@@ -55,9 +55,12 @@ const Example = (props) => {
   };
 
   const _onShareButtonPressed = () => {
-    twilioVideo.current.toggleScreenSharing(!isSharing);
-    setIsSharing(!isSharing);
+    twilioVideo.current.setScreenShareEnabled(!isScreenShareEnabled);
   };
+
+  const _onScreenShareChanged = ({screenShareEnabled = false}) => {
+    setIsScreenShareEnabled(screenShareEnabled);
+  }
 
   const _onFlipButtonPress = () => {
     twilioVideo.current.flipCamera();
@@ -205,7 +208,7 @@ const Example = (props) => {
               onPress={_onShareButtonPressed}
             >
               <Text style={{ fontSize: 12 }}>
-                {isSharing ? "Stop Sharing" : "Start Sharing"}
+                {isScreenShareEnabled ? "Stop Screen Sharing" : "Start Screen Sharing"}
               </Text>
             </TouchableOpacity>
             <TwilioVideoLocalView enabled={true} style={styles.localVideo} />
@@ -217,6 +220,7 @@ const Example = (props) => {
         ref={twilioVideo}
         onRoomDidConnect={_onRoomDidConnect}
         onRoomDidDisconnect={_onRoomDidDisconnect}
+        onScreenShareChanged={_onScreenShareChanged}
         onRoomDidFailToConnect={_onRoomDidFailToConnect}
         onParticipantAddedVideoTrack={_onParticipantAddedVideoTrack}
         onParticipantRemovedVideoTrack={_onParticipantRemovedVideoTrack}

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ import {
 Here you can see a complete example of a simple application that uses almost all the apis:
 
 ````javascript
-import React, { Component, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import {
   TwilioVideoLocalView,
   TwilioVideoParticipantView,
@@ -221,6 +221,7 @@ import {
 const Example = (props) => {
   const [isAudioEnabled, setIsAudioEnabled] = useState(true);
   const [isVideoEnabled, setIsVideoEnabled] = useState(true);
+  const [isScreenShareEnabled, setIsScreenShareEnabled] = useState(false);
   const [status, setStatus] = useState('disconnected');
   const [participants, setParticipants] = useState(new Map());
   const [videoTracks, setVideoTracks] = useState(new Map());
@@ -231,7 +232,7 @@ const Example = (props) => {
     twilioRef.current.connect({ accessToken: token });
     setStatus('connecting');
   }
-  
+
   const _onEndButtonPress = () => {
     twilioRef.current.disconnect();
   };
@@ -241,6 +242,14 @@ const Example = (props) => {
       .setLocalAudioEnabled(!isAudioEnabled)
       .then(isEnabled => setIsAudioEnabled(isEnabled));
   };
+
+  const _onShareButtonPressed = () => {
+    twilioRef.current.setScreenShareEnabled(!isScreenShareEnabled);
+  };
+
+  const _onScreenShareChanged = ({screenShareEnabled = false}) => {
+    setIsScreenShareEnabled(screenShareEnabled);
+  }
 
   const _onFlipButtonPress = () => {
     twilioRef.current.flipCamera();
@@ -310,21 +319,21 @@ const Example = (props) => {
       }
 
       {
-        (status === 'connected' || status === 'connecting') &&
-          <View style={styles.callContainer}>
+        (status === 'connected' || status === 'connecting') && 
+        <View style={styles.callContainer}>
           {
             status === 'connected' &&
             <View style={styles.remoteGrid}>
               {
                 Array.from(videoTracks, ([trackSid, trackIdentifier]) => {
-                  return (
-                    <TwilioVideoParticipantView
-                      style={styles.remoteVideo}
-                      key={trackSid}
-                      trackIdentifier={trackIdentifier}
-                    />
-                  )
-                })
+                return (
+                  <TwilioVideoParticipantView
+                    style={styles.remoteVideo}
+                    key={trackSid}
+                    trackIdentifier={trackIdentifier}
+                  />
+                )
+              })
               }
             </View>
           }
@@ -345,10 +354,17 @@ const Example = (props) => {
               onPress={_onFlipButtonPress}>
               <Text style={{fontSize: 12}}>Flip</Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.optionButton}
+              onPress={_onShareButtonPressed}>
+              <Text style={{ fontSize: 12 }}>
+                {isScreenShareEnabled ? "Stop Screen Sharing" : "Start Screen Sharing"}
+              </Text>
+            </TouchableOpacity>
             <TwilioVideoLocalView
               enabled={true}
               style={styles.localVideo}
-            />
+              />
           </View>
         </View>
       }
@@ -357,6 +373,7 @@ const Example = (props) => {
         ref={ twilioRef }
         onRoomDidConnect={ _onRoomDidConnect }
         onRoomDidDisconnect={ _onRoomDidDisconnect }
+        onScreenShareChanged={ _onScreenShareChanged}
         onRoomDidFailToConnect= { _onRoomDidFailToConnect }
         onParticipantAddedVideoTrack={ _onParticipantAddedVideoTrack }
         onParticipantRemovedVideoTrack= { _onParticipantRemovedVideoTrack }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -16,4 +16,13 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+
+    <application>
+        <service
+            android:enabled="true"
+            android:name=".ScreenCapturerService"
+            android:foregroundServiceType="mediaProjection">
+        </service>
+    </application>
 </manifest>

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -42,6 +42,7 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_STATS_RECEIVE
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_NETWORK_QUALITY_LEVELS_CHANGED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DOMINANT_SPEAKER_CHANGED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_SCREEN_SHARE_CHANGED;
 
 public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilioVideoView> {
     public static final String REACT_CLASS = "RNCustomTwilioVideoView";
@@ -60,6 +61,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     private static final int SEND_STRING = 12;
     private static final int PUBLISH_VIDEO = 13;
     private static final int PUBLISH_AUDIO = 14;
+    private static final int TOGGLE_SCREEN_SHARE = 15;
 
     @Override
     public String getName() {
@@ -108,6 +110,10 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
             case TOGGLE_VIDEO:
                 Boolean videoEnabled = args.getBoolean(0);
                 view.toggleVideo(videoEnabled);
+                break;
+            case TOGGLE_SCREEN_SHARE:
+                Boolean screenShareEnabled = args.getBoolean(0);
+                view.toggleScreenShare(screenShareEnabled);
                 break;
             case TOGGLE_SOUND:
                 Boolean audioEnabled = args.getBoolean(0);
@@ -171,7 +177,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
 
         map.putAll(MapBuilder.of(
                 ON_PARTICIPANT_REMOVED_DATA_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_DATA_TRACK),
-                ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS, MapBuilder.of("registrationName", ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS)
+                ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS, MapBuilder.of("registrationName", ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS),
+                ON_SCREEN_SHARE_CHANGED, MapBuilder.of("registrationName", ON_SCREEN_SHARE_CHANGED)
         ));
 
         map.putAll(MapBuilder.of(
@@ -195,6 +202,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 .put("disconnect", DISCONNECT)
                 .put("switchCamera", SWITCH_CAMERA)
                 .put("toggleVideo", TOGGLE_VIDEO)
+                .put("toggleScreenShare", TOGGLE_SCREEN_SHARE)
                 .put("toggleSound", TOGGLE_SOUND)
                 .put("getStats", GET_STATS)
                 .put("disableOpenSLES", DISABLE_OPENSL_ES)

--- a/android/src/main/java/com/twiliorn/library/ScreenCapturerManager.java
+++ b/android/src/main/java/com/twiliorn/library/ScreenCapturerManager.java
@@ -1,0 +1,73 @@
+/**
+ * Service to orchestrate the Twilio Screen Share connection and the various video
+ * views.
+ * <p>
+ * Authors:
+ * Manish Sahu <msahu2595@gmail.com>
+ */
+package com.twiliorn.library;
+
+import android.annotation.TargetApi;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+
+@TargetApi(29)
+public class ScreenCapturerManager {
+    private ScreenCapturerService mService;
+    private Context mContext;
+    private State currentState = State.UNBIND_SERVICE;
+
+    /** Defines callbacks for service binding, passed to bindService() */
+    private ServiceConnection connection =
+            new ServiceConnection() {
+
+                @Override
+                public void onServiceConnected(ComponentName className, IBinder service) {
+                    // We've bound to ScreenCapturerService, cast the IBinder and get
+                    // ScreenCapturerService instance
+                    ScreenCapturerService.LocalBinder binder =
+                            (ScreenCapturerService.LocalBinder) service;
+                    mService = binder.getService();
+                    currentState = State.BIND_SERVICE;
+                }
+
+                @Override
+                public void onServiceDisconnected(ComponentName arg0) {}
+            };
+
+    /** An enum describing the possible states of a ScreenCapturerManager. */
+    public enum State {
+        BIND_SERVICE,
+        START_FOREGROUND,
+        END_FOREGROUND,
+        UNBIND_SERVICE
+    }
+
+    ScreenCapturerManager(Context context) {
+        mContext = context;
+        bindService();
+    }
+
+    private void bindService() {
+        Intent intent = new Intent(mContext, ScreenCapturerService.class);
+        mContext.bindService(intent, connection, Context.BIND_AUTO_CREATE);
+    }
+
+    void startForeground() {
+        mService.startForeground();
+        currentState = State.START_FOREGROUND;
+    }
+
+    void endForeground() {
+        mService.endForeground();
+        currentState = State.END_FOREGROUND;
+    }
+
+    void unbindService() {
+        mContext.unbindService(connection);
+        currentState = State.UNBIND_SERVICE;
+    }
+}

--- a/android/src/main/java/com/twiliorn/library/ScreenCapturerService.java
+++ b/android/src/main/java/com/twiliorn/library/ScreenCapturerService.java
@@ -1,0 +1,81 @@
+/**
+ * Service to orchestrate the Twilio Screen Share connection and the various video
+ * views.
+ * <p>
+ * Authors:
+ * Manish Sahu <msahu2595@gmail.com>
+ */
+package com.twiliorn.library;
+
+import android.annotation.TargetApi;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.IBinder;
+import android.support.v4.app.NotificationCompat;
+
+@TargetApi(29)
+public class ScreenCapturerService extends Service {
+    private static final String CHANNEL_ID = "screen_capture";
+    private static final String CHANNEL_NAME = "Screen_Capture";
+
+    // Binder given to clients
+    private final IBinder binder = new LocalBinder();
+
+    /**
+     * Class used for the client Binder. We know this service always runs in the same process as its
+     * clients, we don't need to deal with IPC.
+     */
+    public class LocalBinder extends Binder {
+        public ScreenCapturerService getService() {
+            // Return this instance of ScreenCapturerService so clients can call public methods
+            return ScreenCapturerService.this;
+        }
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_NOT_STICKY;
+    }
+
+    public void startForeground() {
+        NotificationChannel chan =
+                new NotificationChannel(
+                        CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_NONE);
+        NotificationManager manager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        assert manager != null;
+        manager.createNotificationChannel(chan);
+
+        final int notificationId = (int) System.currentTimeMillis();
+        NotificationCompat.Builder notificationBuilder =
+                new NotificationCompat.Builder(this, CHANNEL_ID);
+        Notification notification =
+                notificationBuilder
+                        .setOngoing(true)
+                        // .setSmallIcon(R.drawable.ic_screen_share_white_24dp)
+                        .setContentTitle("ScreenCapturerService is running in the foreground")
+                        .setPriority(NotificationManager.IMPORTANCE_MIN)
+                        .setCategory(Notification.CATEGORY_SERVICE)
+                        .build();
+        startForeground(notificationId, notification);
+    }
+
+    public void endForeground() {
+        stopForeground(true);
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Property | Type | Required | Default value | Description
 :--- | :--- | :--- | :--- | :---
 onCameraSwitched | func | no |  | Callback that is called when camera source changes
 onVideoChanged | func | no |  | Callback that is called when video is toggled.
+onScreenShareChanged | func | no |  | Callback that is called when screen share is toggled.
 onAudioChanged | func | no |  | Callback that is called when a audio is toggled.
 onRoomDidConnect | func | no |  | Called when the room has connected  @param {{roomName, participants, localParticipant}}
 onRoomDidFailToConnect | func | no |  | Callback that is called when connecting to room fails.
@@ -46,7 +47,7 @@ onDominantSpeakerDidChange | func | no |  | Called when dominant speaker changes
 
 Property | Type | Required | Default value | Description
 :--- | :--- | :--- | :--- | :---
-screenShare | bool | no |  | Flag that enables screen sharing RCTRootView instead of camera capture
+onScreenShareChanged | func | no |  | Callback that is called when screen share is toggled.
 onRoomDidConnect | func | no |  | Called when the room has connected  @param {{roomName, participants, localParticipant}}
 onRoomDidDisconnect | func | no |  | Called when the room has disconnected  @param {{roomName, error}}
 onRoomDidFailToConnect | func | no |  | Called when connection with room failed  @param {{roomName, error}}

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,7 @@ declare module "react-native-twilio-video-webrtc" {
     onCameraDidStart?: () => void;
     onCameraDidStopRunning?: (err: any) => void;
     onCameraWasInterrupted?: () => void;
+    onScreenShareChanged?: (data: any) => void;
     onDominantSpeakerDidChange?: DominantSpeakerChangedCb;
     onParticipantAddedAudioTrack?: TrackEventCb;
     onParticipantAddedVideoTrack?: TrackEventCb;
@@ -163,6 +164,7 @@ declare module "react-native-twilio-video-webrtc" {
 
   class TwilioVideo extends React.Component<TwilioVideoProps> {
     setLocalVideoEnabled: (enabled: boolean) => Promise<boolean>;
+    setScreenShareEnabled: (enabled: boolean) => void;
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setRemoteAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setBluetoothHeadsetConnected: (enabled: boolean) => Promise<boolean>;

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -31,6 +31,11 @@ const propTypes = {
   onVideoChanged: PropTypes.func,
 
   /**
+     * Callback that is called when screen share permission received.
+     */
+  onScreenShareChanged: PropTypes.func,
+
+  /**
      * Callback that is called when a audio is toggled.
      */
   onAudioChanged: PropTypes.func,
@@ -165,7 +170,8 @@ const nativeEvents = {
   toggleBluetoothHeadset: 11,
   sendString: 12,
   publishVideo: 13,
-  publishAudio: 14
+  publishAudio: 14,
+  toggleScreenShare: 15
 }
 
 class CustomTwilioVideoView extends Component {
@@ -234,6 +240,10 @@ class CustomTwilioVideoView extends Component {
     return Promise.resolve(enabled)
   }
 
+  setScreenShareEnabled (enabled) {
+    this.runCommand(nativeEvents.toggleScreenShare, [enabled])
+  }
+
   setLocalAudioEnabled (enabled) {
     this.runCommand(nativeEvents.toggleSound, [enabled])
     return Promise.resolve(enabled)
@@ -279,6 +289,7 @@ class CustomTwilioVideoView extends Component {
     return [
       'onCameraSwitched',
       'onVideoChanged',
+      'onScreenShareChanged',
       'onAudioChanged',
       'onRoomDidConnect',
       'onRoomDidFailToConnect',

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -15,6 +15,10 @@ const { TWVideoModule } = NativeModules
 export default class TwilioVideo extends Component {
   static propTypes = {
     /**
+     * Callback that is called when screen share permission received.
+     */
+    onScreenShareChanged: PropTypes.func,
+    /**
      * Called when the room has connected
      *
      * @param {{roomName, participants}}
@@ -215,8 +219,8 @@ export default class TwilioVideo extends Component {
   /**
    * Toggle screen sharing
    */
-  toggleScreenSharing (status) {
-    TWVideoModule.toggleScreenSharing(status)
+  setScreenShareEnabled (enabled) {
+    TWVideoModule.toggleScreenShare(enabled)
   }
 
   /**
@@ -330,6 +334,11 @@ export default class TwilioVideo extends Component {
   _registerEvents () {
     TWVideoModule.changeListenerStatus(true)
     this._subscriptions = [
+      this._eventEmitter.addListener('screenShareChanged', (data) => {
+        if (this.props.onScreenShareChanged) {
+          this.props.onScreenShareChanged(data)
+        }
+      }),
       this._eventEmitter.addListener('roomDidConnect', (data) => {
         if (this.props.onRoomDidConnect) {
           this.props.onRoomDidConnect(data)


### PR DESCRIPTION
> This PR adds a `Screen Share` feature on both platforms.
> 
>It can be used by calling `setScreenShareEnabled` & listen to the `onScreenShareChanged` callback.
>
> It solves #535 , #635 , #638 & #618 in which @slycoder was positive about the change.
> 
> Have tested the code and it runs without issues for RN 0.64.4
>
