### PR TITLE
Update TwilioVideo in Android to 7.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,6 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "com.android.support:appcompat-v7:$androidSupportVersion"
-    implementation "com.twilio:video-android:7.3.1"
+    implementation "com.twilio:video-android:7.6.1"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }


### PR DESCRIPTION
This updates TwilioVideo to 7.6.1. Which fixes issues with [How to fix apps with bad WebRTC versions](https://support.google.com/faqs/answer/12577537) that pops up when an app with `react-native-twilio-video-webrtc` gets when uploaded to Play Store.

The changelog for TwilioVideo: [Changelog](https://www.twilio.com/docs/video/changelog-twilio-video-android-v7#761-mar-27-2023). 
> The Twilio Programmable Video SDKs use [Semantic Versioning](http://www.semver.org/).
Which means that this update should contain no breaking changes.

Tested on `web -> android` and works without issues.

Other issues related to this warning: 

- This fixes #642 
- This fixes #672 
- Related https://github.com/twilio/video-quickstart-android/issues/731
