### PR TITLE
docs: Update expo-build-properties installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,8 @@ To use this library with [`Expo`](https://expo.dev) we recommend using our confi
 
 Also you will need to install `expo-build-properties` package:
 
-#### NPM
-
-```bash
-npm i expo-build-properties
-```
-
-#### Yarn
-
-```bash
-yarn add expo-build-properties
+```shell
+npx expo install expo-build-properties
 ```
 
 #### Expo Config Plugin Props


### PR DESCRIPTION
Hi 👋 Thanks for creating the config plugin for Expo!

## Why

We recommend developers use the `npx expo` command for any Expo SDK package. It uses local/versioned [Expo CLI](https://docs.expo.dev/more/expo-cli/) and is tailored for each SDK version because it installs compatible package versions depending on the SDK version.

I saw your tweet about the config plugin PR and was going through the docs and thought this could be a nice enhancement. Sometimes, installing an Expo SDK package using `npm` or `yarn` might lead to incompatibility between Expo SDK's version and the package's version. We (at Expo) also follow the same pattern for installation instructions so that developers do not run into this issue. Example: https://docs.expo.dev/versions/latest/sdk/build-properties/#installation

## How

By updating the command to install `expo-build-properties` package.