### PR TITLE
Upgrade TwilioVideo dependency for iOS

### DIFF
--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 4.6'
+  s.dependency 'TwilioVideo', '~> 5'
 end


### PR DESCRIPTION
Upgrading dependency TwilioVideo > 5

This solved an issue where the local camera on iOS devices was not being added to the remote track server side.