### PR TITLE
fix: updating connect params and avoiding pointers

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -421,7 +421,14 @@ RCT_EXPORT_METHOD(getStats) {
   }
 }
 
-RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL *)enableAudio enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled cameraType:(NSString *)cameraType) {
+RCT_EXPORT_METHOD(connect:(NSString *)accessToken
+                  roomName:(NSString *)roomName
+               enableAudio:(BOOL)enableAudio
+               enableVideo:(BOOL)enableVideo
+         encodingParameters:(NSDictionary *)encodingParameters
+enableNetworkQualityReporting:(BOOL)enableNetworkQualityReporting
+     dominantSpeakerEnabled:(BOOL)dominantSpeakerEnabled
+                cameraType:(NSString *)cameraType) {
   [self _setLocalVideoEnabled:enableVideo cameraType:cameraType];
   if (self.localAudioTrack) {
     [self.localAudioTrack setEnabled:enableAudio];

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -246,7 +246,7 @@ export default class TwilioVideo extends Component {
     cameraType = "front",
     enableAudio = true,
     enableVideo = true,
-    encodingParameters = null,
+    encodingParameters = {},
     enableNetworkQualityReporting = false,
     dominantSpeakerEnabled = false,
   }) {


### PR DESCRIPTION
I just started to experience an issue where my "connect" function wasn't getting called in objective-c. Aftering some debugging, I realized that it was caused by the implementation of BOOL * instead of BOOL


```
RCT_EXPORT_METHOD(
  connect:(NSString *)accessToken 
  roomName:(NSString *)roomName 
  enableAudio:(BOOL *)enableAudio 
  enableVideo:(BOOL *)enableVideo 
  encodingParameters:(NSDictionary *)encodingParameters 
  enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting 
  dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled 
  cameraType:(NSString *)cameraType
) {
```

VS

```
RCT_EXPORT_METHOD(connect:(NSString *)accessToken
                  roomName:(NSString *)roomName
               enableAudio:(BOOL)enableAudio
               enableVideo:(BOOL)enableVideo
         encodingParameters:(NSDictionary *)encodingParameters
enableNetworkQualityReporting:(BOOL)enableNetworkQualityReporting
     dominantSpeakerEnabled:(BOOL)dominantSpeakerEnabled
                cameraType:(NSString *)cameraType) {
```


In Objective-C, BOOL is a primitive, not a pointer. Using BOOL * (a pointer) is incorrect unless handling pointers, which we're not doing here. I'm thinking that the BOOL * type may confuse the RN bridge, causing it to drop the method call silently? 

And then another change is the default param of `encodingParameters` from the js should be a dict not null.