### PR TITLE
Fix "Objective C type BOOL is unsupported"

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -421,7 +421,7 @@ RCT_EXPORT_METHOD(getStats) {
   }
 }
 
-RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL *)enableAudio enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled cameraType:(NSString *)cameraType) {
+RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL)enableAudio enableVideo:(BOOL)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL)dominantSpeakerEnabled cameraType:(NSString *)cameraType) {
   [self _setLocalVideoEnabled:enableVideo cameraType:cameraType];
   if (self.localAudioTrack) {
     [self.localAudioTrack setEnabled:enableAudio];


### PR DESCRIPTION
Resolve https://github.com/blackuy/react-native-twilio-video-webrtc/issues/763

STR:
 - call `connect()`

Expected
 - no errors, call connects

Actual
> (NOBRIDGE) LOG  [Error: TWVideoModule.connect(): Error while converting JavaScript argument 2 to Objective C type BOOL. Objective C type BOOL is unsupported.]

Fix
Replace all instances of `BOOL *` with `BOOL` in the connect method signature. This change should be safe:
- These parameters are only used as input values, not for returning data
- The JavaScript API surface remains unchanged
- The parameters are immediately used in the method without storing references

Inspired by https://github.com/FormidableLabs/react-native-app-auth/issues/980#issuecomment-2223008235