### PR TITLE
Fix Error: Component "CustomTwilioVideoView" contains the string ref "videoView" crash on rn v0.79+ new arch

### DIFF
--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -170,6 +170,10 @@ const nativeEvents = {
 };
 
 class CustomTwilioVideoView extends Component {
+  constructor(props) {
+    super(props);
+    this.twilioRef = React.createRef();
+  }
   connect({
     roomName,
     accessToken,
@@ -271,7 +275,7 @@ class CustomTwilioVideoView extends Component {
     switch (Platform.OS) {
       case "android":
         UIManager.dispatchViewManagerCommand(
-          findNodeHandle(this.refs.videoView),
+          findNodeHandle(this.twilioRef.current),
           event,
           args
         );
@@ -320,7 +324,7 @@ class CustomTwilioVideoView extends Component {
   render() {
     return (
       <NativeCustomTwilioVideoView
-        ref="videoView"
+        ref={this.twilioRef}
         {...this.props}
         {...this.buildNativeEventWrappers()}
       />


### PR DESCRIPTION
This PR fixes #751 by implementing the solution proposed in [this comment](https://github.com/blackuy/react-native-twilio-video-webrtc/issues/751#issuecomment-2596658163).
