### PR TITLE
fix(#555): drop removed View.propTypes spread that breaks RN 0.63 plus

### DIFF
--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -10,7 +10,6 @@
 import {
   Platform,
   UIManager,
-  View,
   findNodeHandle,
   requireNativeComponent,
 } from "react-native";
@@ -19,7 +18,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 const propTypes = {
-  ...View.propTypes,
   /**
    * Callback that is called when camera source changes
    */

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -152,7 +152,6 @@ export default class TwilioVideo extends Component {
      * camera will require calling `_startLocalVideo`.
      */
     autoInitializeCamera: PropTypes.bool,
-    ...View.propTypes,
   };
 
   constructor(props) {


### PR DESCRIPTION
Closes blackuy/react-native-twilio-video-webrtc#555.

## Why the call sometimes failed
Both `TwilioVideo` components copy the host `View` prop list with `...View.propTypes` so consumers can pass through native view props. That field was removed from React Native in version 0.63 and now resolves to `undefined`. Spreading it into an object literal is silent at runtime, but as soon as a downstream consumer or a PropTypes-aware helper reaches for the resulting list it goes through Babel's `_toConsumableArray`, which throws the exact error reported in the issue.

```text
[TypeError: Invalid attempt to spread non-iterable instance.
In order to be iterable, non-array objects must have a [Symbol.iterator]() method.]
```

## Fix
Remove the dead spread from both the Android and iOS components and drop the now-unused `View` import on Android.

```javascript
// src/TwilioVideo.android.js
const propTypes = {
  /** Callback that is called when camera source changes */
  onCameraSwitched: PropTypes.func,
```

```javascript
// src/TwilioVideo.ios.js
    autoInitializeCamera: PropTypes.bool,
  };
```

The remaining explicit `PropTypes.func`, `PropTypes.bool`, `PropTypes.string` entries fully describe the public API, so consumers keep the same prop validation behaviour they had on RN 0.62 and earlier.
